### PR TITLE
Fix XML documentation parameter mismatches

### DIFF
--- a/src/ECMABasic.Core/CharacterReader.cs
+++ b/src/ECMABasic.Core/CharacterReader.cs
@@ -41,6 +41,7 @@ namespace ECMABasic.Core
         /// Create a new instance of <see cref="CharacterReader"/>.
         /// </summary>
         /// <param name="source">The source to pull the token text from.</param>
+        /// <param name="config">Optional BASIC configuration settings.</param>
         public CharacterReader(Stream source, IBasicConfiguration? config = null)
         {
             _config = config ?? MinimalBasicConfiguration.Instance;

--- a/src/ECMABasic.Core/Interpreter.cs
+++ b/src/ECMABasic.Core/Interpreter.cs
@@ -48,7 +48,8 @@ namespace ECMABasic.Core
 		/// Create an interpreter that will interpret the input text directly.
 		/// </summary>
 		/// <param name="text">The text to interpret.</param>
-		/// <param name="reporter">A receiver for error messages.</param>
+		/// <param name="env">The execution environment.</param>
+		/// <param name="config">Optional BASIC configuration settings.</param>
 		/// <returns>Was the input interpreted successfully?</returns>
 		public static bool FromText(string text, IEnvironment env, IBasicConfiguration? config = null)
 		{
@@ -60,7 +61,8 @@ namespace ECMABasic.Core
 		/// Create an interpreter that will interpret the source text contained at the file path.
 		/// </summary>
 		/// <param name="path">The path to the file to interpret.</param>
-		/// <param name="reporter">A receiver for error messages.</param>
+		/// <param name="env">The execution environment.</param>
+		/// <param name="config">Optional BASIC configuration settings.</param>
 		/// <returns>Was the input interpreted successfully?</returns>
 		public static bool FromFile(string path, IEnvironment env, IBasicConfiguration? config = null)
 		{
@@ -80,8 +82,8 @@ namespace ECMABasic.Core
 		/// <summary>
 		/// Interpret the source text contained at the file path.
 		/// </summary>
+		/// <param name="env">The execution environment.</param>
 		/// <param name="path">The path to the file to interpret.</param>
-		/// <param name="reporter">A receiver for error messages.</param>
 		/// <returns>Was the input interpreted successfully?</returns>
 		public bool InterpretProgramFromFile(IEnvironment env, string path)
 		{
@@ -92,8 +94,8 @@ namespace ECMABasic.Core
 		/// <summary>
 		/// Interpret the input text directly.
 		/// </summary>
+		/// <param name="env">The execution environment.</param>
 		/// <param name="text">The text to interpret.</param>
-		/// <param name="reporter">A receiver for error messages.</param>
 		/// <returns>Was the input interpreted successfully?</returns>
 		public bool InterpretProgramFromText(IEnvironment env, string text)
 		{

--- a/src/ECMABasic.Core/ProgramLine.cs
+++ b/src/ECMABasic.Core/ProgramLine.cs
@@ -12,6 +12,7 @@ namespace ECMABasic.Core
         /// </summary>
         /// <param name="lineNumber">The line number.</param>
         /// <param name="statement">The statement to execute on this line.</param>
+        /// <param name="parent">The parent FOR block, if any.</param>
         public ProgramLine(int lineNumber, IStatement? statement, ProgramLine? parent)
         {
             LineNumber = lineNumber;

--- a/src/ECMABasic.Core/StatementParser.cs
+++ b/src/ECMABasic.Core/StatementParser.cs
@@ -17,6 +17,7 @@ namespace ECMABasic.Core
 		/// Read whitespace off of the token stream.
 		/// An exception will optionally occur if whitespace could not be found.
 		/// </summary>
+		/// <param name="reader">The token reader.</param>
 		/// <param name="throwOnError">Throw an exception if space is not found.  Default to true.</param>
 		/// <returns>The space token, or null if not found and throwOnError is false.</returns>
 		protected static Token? ProcessSpace(ComplexTokenReader reader, bool throwOnError = true)

--- a/src/ECMABasic.Core/Statements/GotoStatement.cs
+++ b/src/ECMABasic.Core/Statements/GotoStatement.cs
@@ -20,6 +20,7 @@ namespace ECMABasic.Core.Statements
 		/// <summary>
 		/// The <paramref name="src"/> parent tree needs to contain the parent of <paramref name="dst"/>.
 		/// </summary>
+		/// <param name="env">The execution environment.</param>
 		/// <param name="src">The line jumping from.</param>
 		/// <param name="dst">The line jumping to.</param>
 		private void ValidateSharedAncestry(IEnvironment env, ProgramLine? src, ProgramLine dst)


### PR DESCRIPTION
## Summary
Fixes XML documentation parameter mismatches introduced during nullable modernization.

## Changes
Updated XML `<param>` tags in 5 files to match actual method signatures:

**CharacterReader.cs**:
- Added missing `<param name="config">` for optional configuration parameter

**Interpreter.cs** (4 methods):
- Changed incorrect `<param name="reporter">` to `<param name="env">`
- Added missing `<param name="config">` tags

**ProgramLine.cs**:
- Added missing `<param name="parent">` tag

**StatementParser.cs**:
- Added missing `<param name="reader">` for ProcessSpace()

**GotoStatement.cs**:
- Added missing `<param name="env">` for ValidateSharedAncestry()

## Errors Fixed
- CS1572: XML comment has param tag but no matching parameter
- CS1573: Parameter has no matching param tag

## Build Status
- ✅ Zero CS compiler errors
- ✅ All XML documentation matches method signatures

## Related
Relates to #5 (cleanup after nullable modernization)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)