### PR TITLE
Convert to file-scoped namespaces (IDE0161)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,8 @@
+# TODO
+
+* Convert `appsettings.json` to YAML format and update the config loaders.
+* Clean Architecture in C# generally has projects for infrastructure, domain, application, and presentation, in addition to the test projects.
+    1. `ECMABasic55` is the presentation layer.
+    2. Let's rename `ECMABasic.Core` to `ECMABasic.Application`.
+    3. `ECMABasic.Test` should be moved from `./src` to `./test` and renamed to `ECMABasic.Application.Test`.
+    4. The `ECMABasic.Application` and `ECMABasic.Application.Test` projects should be reviewed for anything that should be moved to the Domain or Infrastructure layers.

--- a/src/ECMABasic.Core/CharacterReader.cs
+++ b/src/ECMABasic.Core/CharacterReader.cs
@@ -5,334 +5,333 @@ using System.IO;
 using System.Linq;
 using System.Text;
 
-namespace ECMABasic.Core
+namespace ECMABasic.Core;
+
+/// <summary>
+/// Read a sequence of characters from a text source.
+/// </summary>
+/// <remarks>
+/// The source stream is constructed outside of this class's scope; it will also need to be disposed of outside of this class's scope.
+/// </remarks>
+public class CharacterReader : IDisposable
 {
+    #region Constants
+
+    private const string LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    private const string DIGITS = "0123456789";
+    private const string SYMBOLS = "!\"%&'()*+,-./:;<=>?_#$#@[\\]^`{|}~";
+    private const string SPACES = " \t";
+    private const char CARRIAGE_RETURN = (char)13;
+    private const char LINE_FEED = (char)10;
+
+    #endregion
+
+    #region Fields
+
+    private readonly IBasicConfiguration _config;
+    private readonly Stream _source;
+    private readonly TextReader _reader;
+    private bool _disposedValue;
+
+    #endregion
+
+    #region Constructors
+
     /// <summary>
-    /// Read a sequence of characters from a text source.
+    /// Create a new instance of <see cref="CharacterReader"/>.
     /// </summary>
-    /// <remarks>
-    /// The source stream is constructed outside of this class's scope; it will also need to be disposed of outside of this class's scope.
-    /// </remarks>
-    public class CharacterReader : IDisposable
+    /// <param name="source">The source to pull the token text from.</param>
+    /// <param name="config">Optional BASIC configuration settings.</param>
+    public CharacterReader(Stream source, IBasicConfiguration? config = null)
     {
-        #region Constants
+        _config = config ?? MinimalBasicConfiguration.Instance;
+        _source = source;
+        _reader = new StreamReader(_source, leaveOpen: true);
+        LineNumber = 1;
+        ColumnNumber = 1;
+        ValidateLineLengths();
+    }
 
-        private const string LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-        private const string DIGITS = "0123456789";
-        private const string SYMBOLS = "!\"%&'()*+,-./:;<=>?_#$#@[\\]^`{|}~";
-        private const string SPACES = " \t";
-        private const char CARRIAGE_RETURN = (char)13;
-        private const char LINE_FEED = (char)10;
+    #endregion
 
-        #endregion
+    #region Properties
 
-        #region Fields
-
-        private readonly IBasicConfiguration _config;
-        private readonly Stream _source;
-        private readonly TextReader _reader;
-        private bool _disposedValue;
-
-        #endregion
-
-        #region Constructors
-
-        /// <summary>
-        /// Create a new instance of <see cref="CharacterReader"/>.
-        /// </summary>
-        /// <param name="source">The source to pull the token text from.</param>
-        /// <param name="config">Optional BASIC configuration settings.</param>
-        public CharacterReader(Stream source, IBasicConfiguration? config = null)
+    public string SourceText
+    {
+        get
         {
-            _config = config ?? MinimalBasicConfiguration.Instance;
-            _source = source;
-            _reader = new StreamReader(_source, leaveOpen: true);
-            LineNumber = 1;
-            ColumnNumber = 1;
-            ValidateLineLengths();
-        }
+            var position = _source.Position;
+            _source.Position = 0;
+			using var reader = new StreamReader(_source, leaveOpen: true);
+			var text = reader.ReadToEnd();
+			_source.Position = position;
+			return text;
+		}
+    }
+    public int LineNumber { get; private set; }
+    public int ColumnNumber { get; private set; }
+    public bool IsAtEnd => _reader.Peek() == -1;
 
-        #endregion
+    #endregion
 
-        #region Properties
+    #region Methods
 
-        public string SourceText
+    public string ReadInteger()
+    {
+        var sb = new StringBuilder();
+        sb.Append(RequireDigit());
+        while (true)
         {
-            get
-            {
-                var position = _source.Position;
-                _source.Position = 0;
-				using var reader = new StreamReader(_source, leaveOpen: true);
-				var text = reader.ReadToEnd();
-				_source.Position = position;
-				return text;
-			}
-        }
-        public int LineNumber { get; private set; }
-        public int ColumnNumber { get; private set; }
-        public bool IsAtEnd => _reader.Peek() == -1;
-
-        #endregion
-
-        #region Methods
-
-        public string ReadInteger()
-        {
-            var sb = new StringBuilder();
-            sb.Append(RequireDigit());
-            while (true)
-            {
-                var ch = Peek();
-                if (IsDigit(ch))
-                {
-                    sb.Append(ch);
-                    Next();
-                }
-                else
-                {
-                    break;
-                }
-            }
-            return sb.ToString();
-        }
-
-        public string ReadWord()
-        {
-            var sb = new StringBuilder();
-            sb.Append(RequireLetter());
-            while (true)
-            {
-                var ch = Peek();
-                if (IsLetter(ch))
-                {
-                    sb.Append(ch);
-                    Next();
-                }
-                else
-                {
-                    break;
-                }
-            }
-            return sb.ToString();
-        }
-
-        public string ReadSymbol()
-        {
-            var sb = new StringBuilder();
-            sb.Append(RequireSymbol());
-            return sb.ToString();
-        }
-
-        public string ReadSpace()
-        {
-            var sb = new StringBuilder();
-            sb.Append(RequireSpace());
-            while (true)
-            {
-                var ch = Peek();
-                if (IsSpace(ch))
-                {
-                    sb.Append(ch);
-                    Next();
-                }
-                else
-                {
-                    break;
-                }
-            }
-            return sb.ToString();
-        }
-
-        public string ReadEndOfLine()
-		{
-            var sb = new StringBuilder();
-
-            var eol = RequireEndOfLine();
-            sb.Append(eol);
-
-            // The line-feed character is optional, but should still be recorded.
             var ch = Peek();
-            if (((eol == CARRIAGE_RETURN) && (ch == LINE_FEED)) || ((eol == LINE_FEED) && (ch == CARRIAGE_RETURN)))
+            if (IsDigit(ch))
             {
                 sb.Append(ch);
                 Next();
             }
-
-            return sb.ToString();
-		}
-
-        /// <summary>
-        /// Require that a single letter be next in the token stream.
-        /// Move to the next byte, and throw an exception if the token doesn't match.
-        /// </summary>
-        /// <returns>
-        /// The letter that was read.
-        /// </returns>
-        public char RequireLetter()
-        {
-            var ch = Peek();
-            if (!IsLetter(ch))
+            else
             {
-                throw new UnexpectedCharacterException(LineNumber, ColumnNumber, LETTERS, ch);
-            }
-            Next();
-            return ch;
-        }
-
-        /// <summary>
-        /// Require that a single digit be next in the token stream.
-        /// Move to the next byte, and throw an exception if the token doesn't match.
-        /// </summary>
-        /// <returns>
-        /// The digit that was read.
-        /// </returns>
-        public char RequireDigit()
-        {
-            var ch = Peek();
-            if (!IsDigit(ch))
-            {
-                throw new UnexpectedCharacterException(LineNumber, ColumnNumber, LETTERS, ch);
-            }
-            Next();
-            return ch;
-        }
-
-        /// <summary>
-        /// Require that a single symbol be next in the token stream.
-        /// Move to the next byte, and throw an exception if the token doesn't match.
-        /// </summary>
-        /// <returns>
-        /// The symbol that was read.
-        /// </returns>
-        public char RequireSymbol()
-        {
-            var ch = Peek();
-            if (!IsSymbol(ch))
-            {
-                throw new UnexpectedCharacterException(LineNumber, ColumnNumber, SYMBOLS, ch);
-            }
-            Next();
-            return ch;
-        }
-
-        /// <summary>
-        /// Require that a single space be next in the token stream.
-        /// Move to the next byte, and throw an exception if the token doesn't match.
-        /// </summary>
-        /// <returns>
-        /// The space that was read.
-        /// </returns>
-        public char RequireSpace()
-        {
-            var ch = Peek();
-            if (!IsSpace(ch))
-            {
-                throw new UnexpectedCharacterException(LineNumber, ColumnNumber, SPACES, ch);
-            }
-            Next();
-            return ch;
-        }
-
-        public char RequireEndOfLine()
-        {
-            var ch = Peek();
-            if ((ch != CARRIAGE_RETURN) && (ch != LINE_FEED))
-            {
-                throw new UnexpectedCharacterException(LineNumber, ColumnNumber, "end-of-line", ch);
-            }
-            Next();
-            return ch;
-        }
-
-        public static bool IsLetter(char ch)
-        {
-            return LETTERS.Contains(ch);
-        }
-
-        public static bool IsDigit(char ch)
-        {
-            return DIGITS.Contains(ch);
-        }
-
-        public static bool IsSpace(char ch)
-        {
-            return SPACES.Contains(ch);
-        }
-
-        public static bool IsSymbol(char ch)
-        {
-            return SYMBOLS.Contains(ch);
-        }
-
-        public static bool IsEndOfLine(char ch)
-        {
-            return (ch == CARRIAGE_RETURN) || (ch == LINE_FEED);
-        }
-
-        public char Peek()
-        {
-            return (char)_reader.Peek();
-        }
-
-        public char Next()
-        {
-            var ch = (char)_reader.Read();
-            ColumnNumber++;
-
-            if (((ch == LINE_FEED) && (Peek() != CARRIAGE_RETURN)) ||
-                ((ch == CARRIAGE_RETURN) && (Peek() != LINE_FEED)))
-			{
-                LineNumber++;
-                ColumnNumber = 1;
-			}
-
-            return ch;
-        }
-
-        private void ValidateLineLengths()
-		{
-            // Minimal BASIC doesn't allow source lines longer than 72 characters.
-            var longLine = SourceText.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault(x => x.Length > _config.MaxLineLength);
-
-            if (longLine == null)
-			{
-                // No long lines were found.
-                return;
-			}
-
-            // Try to grab the line number.
-            var lineNumberText = longLine.Split(' ').First();
-			if (!int.TryParse(lineNumberText, out var lineNumber))
-			{
-                throw ExceptionFactory.LineNumberExpected();
-			}
-
-			throw ExceptionFactory.LineTooLong(longLine.Length - _config.MaxLineLength, lineNumber);
-		}
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!_disposedValue)
-            {
-                if (disposing)
-                {
-                    _reader.Dispose();
-                }
-
-                _disposedValue = true;
+                break;
             }
         }
-
-        /// <summary>
-        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
-        /// </summary>
-        public void Dispose()
-        {
-            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-            Dispose(disposing: true);
-            GC.SuppressFinalize(this);
-        }
-
-        #endregion
+        return sb.ToString();
     }
+
+    public string ReadWord()
+    {
+        var sb = new StringBuilder();
+        sb.Append(RequireLetter());
+        while (true)
+        {
+            var ch = Peek();
+            if (IsLetter(ch))
+            {
+                sb.Append(ch);
+                Next();
+            }
+            else
+            {
+                break;
+            }
+        }
+        return sb.ToString();
+    }
+
+    public string ReadSymbol()
+    {
+        var sb = new StringBuilder();
+        sb.Append(RequireSymbol());
+        return sb.ToString();
+    }
+
+    public string ReadSpace()
+    {
+        var sb = new StringBuilder();
+        sb.Append(RequireSpace());
+        while (true)
+        {
+            var ch = Peek();
+            if (IsSpace(ch))
+            {
+                sb.Append(ch);
+                Next();
+            }
+            else
+            {
+                break;
+            }
+        }
+        return sb.ToString();
+    }
+
+    public string ReadEndOfLine()
+	{
+        var sb = new StringBuilder();
+
+        var eol = RequireEndOfLine();
+        sb.Append(eol);
+
+        // The line-feed character is optional, but should still be recorded.
+        var ch = Peek();
+        if (((eol == CARRIAGE_RETURN) && (ch == LINE_FEED)) || ((eol == LINE_FEED) && (ch == CARRIAGE_RETURN)))
+        {
+            sb.Append(ch);
+            Next();
+        }
+
+        return sb.ToString();
+	}
+
+    /// <summary>
+    /// Require that a single letter be next in the token stream.
+    /// Move to the next byte, and throw an exception if the token doesn't match.
+    /// </summary>
+    /// <returns>
+    /// The letter that was read.
+    /// </returns>
+    public char RequireLetter()
+    {
+        var ch = Peek();
+        if (!IsLetter(ch))
+        {
+            throw new UnexpectedCharacterException(LineNumber, ColumnNumber, LETTERS, ch);
+        }
+        Next();
+        return ch;
+    }
+
+    /// <summary>
+    /// Require that a single digit be next in the token stream.
+    /// Move to the next byte, and throw an exception if the token doesn't match.
+    /// </summary>
+    /// <returns>
+    /// The digit that was read.
+    /// </returns>
+    public char RequireDigit()
+    {
+        var ch = Peek();
+        if (!IsDigit(ch))
+        {
+            throw new UnexpectedCharacterException(LineNumber, ColumnNumber, LETTERS, ch);
+        }
+        Next();
+        return ch;
+    }
+
+    /// <summary>
+    /// Require that a single symbol be next in the token stream.
+    /// Move to the next byte, and throw an exception if the token doesn't match.
+    /// </summary>
+    /// <returns>
+    /// The symbol that was read.
+    /// </returns>
+    public char RequireSymbol()
+    {
+        var ch = Peek();
+        if (!IsSymbol(ch))
+        {
+            throw new UnexpectedCharacterException(LineNumber, ColumnNumber, SYMBOLS, ch);
+        }
+        Next();
+        return ch;
+    }
+
+    /// <summary>
+    /// Require that a single space be next in the token stream.
+    /// Move to the next byte, and throw an exception if the token doesn't match.
+    /// </summary>
+    /// <returns>
+    /// The space that was read.
+    /// </returns>
+    public char RequireSpace()
+    {
+        var ch = Peek();
+        if (!IsSpace(ch))
+        {
+            throw new UnexpectedCharacterException(LineNumber, ColumnNumber, SPACES, ch);
+        }
+        Next();
+        return ch;
+    }
+
+    public char RequireEndOfLine()
+    {
+        var ch = Peek();
+        if ((ch != CARRIAGE_RETURN) && (ch != LINE_FEED))
+        {
+            throw new UnexpectedCharacterException(LineNumber, ColumnNumber, "end-of-line", ch);
+        }
+        Next();
+        return ch;
+    }
+
+    public static bool IsLetter(char ch)
+    {
+        return LETTERS.Contains(ch);
+    }
+
+    public static bool IsDigit(char ch)
+    {
+        return DIGITS.Contains(ch);
+    }
+
+    public static bool IsSpace(char ch)
+    {
+        return SPACES.Contains(ch);
+    }
+
+    public static bool IsSymbol(char ch)
+    {
+        return SYMBOLS.Contains(ch);
+    }
+
+    public static bool IsEndOfLine(char ch)
+    {
+        return (ch == CARRIAGE_RETURN) || (ch == LINE_FEED);
+    }
+
+    public char Peek()
+    {
+        return (char)_reader.Peek();
+    }
+
+    public char Next()
+    {
+        var ch = (char)_reader.Read();
+        ColumnNumber++;
+
+        if (((ch == LINE_FEED) && (Peek() != CARRIAGE_RETURN)) ||
+            ((ch == CARRIAGE_RETURN) && (Peek() != LINE_FEED)))
+		{
+            LineNumber++;
+            ColumnNumber = 1;
+		}
+
+        return ch;
+    }
+
+    private void ValidateLineLengths()
+	{
+        // Minimal BASIC doesn't allow source lines longer than 72 characters.
+        var longLine = SourceText.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault(x => x.Length > _config.MaxLineLength);
+
+        if (longLine == null)
+		{
+            // No long lines were found.
+            return;
+		}
+
+        // Try to grab the line number.
+        var lineNumberText = longLine.Split(' ').First();
+		if (!int.TryParse(lineNumberText, out var lineNumber))
+		{
+            throw ExceptionFactory.LineNumberExpected();
+		}
+
+		throw ExceptionFactory.LineTooLong(longLine.Length - _config.MaxLineLength, lineNumber);
+	}
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposedValue)
+        {
+            if (disposing)
+            {
+                _reader.Dispose();
+            }
+
+            _disposedValue = true;
+        }
+    }
+
+    /// <summary>
+    /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+    /// </summary>
+    public void Dispose()
+    {
+        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+
+    #endregion
 }

--- a/src/ECMABasic.Core/ComplexTokenReader.cs
+++ b/src/ECMABasic.Core/ComplexTokenReader.cs
@@ -4,269 +4,264 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 
-namespace ECMABasic.Core
+namespace ECMABasic.Core;
+
+// TODO: Do I *really* need to tokenizers?
+
+/// <summary>
+/// Assembly simple tokens into more complex tokens, e.g. strings, keywords, and operators.
+/// </summary>
+/// <remarks>
+/// This is where the lexical analysis really happens.
+/// </remarks>
+public class ComplexTokenReader
 {
-	// TODO: Do I *really* need to tokenizers?
+	private readonly List<Token> _tokens;
+
+	private ComplexTokenReader(SimpleTokenReader reader)
+	{
+		_tokens = new List<Token>();
+		while (!reader.IsAtEnd)
+		{
+			var token = reader.Next();
+			if (token != null)
+			{
+				_tokens.Add(token);
+			}
+		}
+
+		reader.Dispose();
+	}
 
 	/// <summary>
-	/// Assembly simple tokens into more complex tokens, e.g. strings, keywords, and operators.
+	/// The index into _tokens.
+	/// </summary>
+	public int TokenIndex { get; private set; }
+
+	public bool IsAtEnd => TokenIndex >= _tokens.Count;
+
+	public static ComplexTokenReader FromFile(string filename)
+	{
+		return new ComplexTokenReader(SimpleTokenReader.FromFile(filename));
+	}
+
+	public static ComplexTokenReader FromText(string text)
+	{
+		return new ComplexTokenReader(SimpleTokenReader.FromText(text));
+	}
+
+	/// <summary>
+	/// Read an integer off of the token stream.
+	/// </summary>
+	/// <param name="maxDigits">If > 0, don't read any more digits than this.</param>
+	/// <param name="throwOnError">If true, an exception will be thrown if an integer coule not be read.</param>
+	/// <returns>The integer that was read.</returns>
+	/// <exception cref="UnexpectedTokenException">Throws an exception if an integer could not be read.</exception>
+	public int? NextInteger(int maxDigits = 0, bool throwOnError = true)
+	{
+		var signToken = Next(TokenType.Symbol, false, @"\+");
+		if (signToken == null)
+		{
+			signToken = Next(TokenType.Symbol, false, @"\-");
+		}
+		var isNegative = signToken?.Text == "-";
+
+		var token = Next(TokenType.Integer, throwOnError);
+		if (token == null)
+		{
+			return null;
+		}
+
+		if ((maxDigits > 1) && (token.Text.Length > maxDigits))
+		{
+			throw new SyntaxException($"({token.Line}:{token.Column}) INTEGER OVERFLOW");
+		}
+
+		var value = int.Parse(token.Text);
+		if (isNegative)
+		{
+			value = -value;
+		}
+		return value;
+	}
+
+	/// <summary>
+	/// Read a number off of the token stream.  The number can have a decimal point.
+	/// </summary>
+	/// <param name="throwOnError">If true, an exception will be thrown if an integer coule not be read.</param>
+	/// <returns>The number that was read.</returns>
+	/// <exception cref="UnexpectedTokenException">Throws an exception if an integer could not be read.</exception>
+	public double? NextNumber(bool throwOnError = true)
+	{
+		var signToken = Next(TokenType.Symbol, false, @"\+");
+		if (signToken == null)
+		{
+			signToken = Next(TokenType.Symbol, false, @"\-");
+		}
+
+		var integerToken = Next(TokenType.Integer, false);
+		var decimalToken = Next(TokenType.DecimalPoint, false);
+		string valueText;
+		if ((decimalToken == null) && (integerToken != null))
+		{
+			valueText = string.Concat(signToken?.Text ?? string.Empty, integerToken.Text, ".0");
+		}
+		else
+		{
+			var fractionToken = Next(TokenType.Integer, throwOnError);
+			if ((fractionToken == null) && (integerToken == null))
+			{
+				return null;
+			}
+
+			valueText = string.Concat(signToken?.Text ?? string.Empty, integerToken?.Text ?? string.Empty, ".", fractionToken?.Text ?? string.Empty);
+		}
+
+		// TODO: I don't really like how the "E" is typed here.
+		var exradToken = Next(TokenType.Word, false, @"E\d?");
+		if (exradToken != null)
+		{
+			var signText = string.Empty;
+			if (exradToken.Text == "E")
+			{
+				var exsignToken = Next(TokenType.Symbol, false, @"\+");
+				if (exsignToken == null)
+				{
+					exsignToken = Next(TokenType.Symbol, false, @"\-");
+				}
+				signText = exsignToken?.Text ?? string.Empty;
+			}
+
+			Token? powerToken = null;
+			if (!char.IsDigit(exradToken.Text.Last()))
+			{
+				powerToken = Next(TokenType.Integer, true);
+			}
+
+			valueText = string.Concat(valueText, exradToken.Text, signText, powerToken?.Text ?? string.Empty);
+		}
+
+		try
+		{
+			return double.Parse(valueText, System.Globalization.NumberStyles.Float);
+		}
+		catch (OverflowException ex)
+		{
+			throw new OverflowException($"'{valueText}' couldn't be converted.", ex);
+		}
+	}
+
+	/// <summary>
+	/// Get the next token off the stream, verifying the token type.
+	/// A null token will be returned if the type doesn't match, or optionally an exception will be thrown instead.
+	/// If a null token is returned, the reader will not be advanced to the next token.
+	/// </summary>
+	/// <param name="type">The type of token to retrieve.</param>
+	/// <param name="throwOnError">If true, an exception will be thrown if the type does not match.</param>
+	/// <param name="pattern">An optional regular expression pattern to match on the next token text.</param>
+	/// <returns>The token that was read.</returns>
+	/// <exception cref="UnexpectedTokenException">Throws an exception if the token type doesn't match what was expected.</exception>
+	public Token? Next(TokenType type, bool throwOnError = true, string? pattern = null)
+	{
+		var startPosition = TokenIndex;
+		var token = Next();
+		if ((token == null) || (token.Type != type) || ((pattern != null) && !Regex.IsMatch(token.Text, @"^" + pattern + @"$", RegexOptions.Singleline)))
+		{
+			if (throwOnError)
+			{
+				throw new UnexpectedTokenException(type, token);
+			}
+			else
+			{
+				TokenIndex = startPosition;
+				return null;
+			}
+		}
+		else
+		{
+			return token;
+		}
+	}
+
+	/// <summary>
+	/// Pull the next token off of the stream.
 	/// </summary>
 	/// <remarks>
-	/// This is where the lexical analysis really happens.
+	/// No semantic analysis at this phase; that comes next.
 	/// </remarks>
-	public class ComplexTokenReader
+	/// <returns>The token that was read, or null at the end of the stream.</returns>
+	public Token? Next()
 	{
-		private readonly List<Token> _tokens;
-
-		private ComplexTokenReader(SimpleTokenReader reader)
+		if (IsAtEnd)
 		{
-			_tokens = new List<Token>();
-			while (!reader.IsAtEnd)
-			{
-				var token = reader.Next();
-				if (token != null)
-				{
-					_tokens.Add(token);
-				}
-			}
-
-			reader.Dispose();
+			return null;
 		}
 
-		/// <summary>
-		/// The index into _tokens.
-		/// </summary>
-		public int TokenIndex { get; private set; }
+		var token = Read();
 
-		public bool IsAtEnd => TokenIndex >= _tokens.Count;
-
-		public static ComplexTokenReader FromFile(string filename)
+		if (token?.Type == TokenType.Symbol)
 		{
-			return new ComplexTokenReader(SimpleTokenReader.FromFile(filename));
-		}
-
-		public static ComplexTokenReader FromText(string text)
-		{
-			return new ComplexTokenReader(SimpleTokenReader.FromText(text));
-		}
-
-		/// <summary>
-		/// Read an integer off of the token stream.
-		/// </summary>
-		/// <param name="maxDigits">If > 0, don't read any more digits than this.</param>
-		/// <param name="throwOnError">If true, an exception will be thrown if an integer coule not be read.</param>
-		/// <returns>The integer that was read.</returns>
-		/// <exception cref="UnexpectedTokenException">Throws an exception if an integer could not be read.</exception>
-		public int? NextInteger(int maxDigits = 0, bool throwOnError = true)
-		{
-			var signToken = Next(TokenType.Symbol, false, @"\+");
-			if (signToken == null)
+			if (token.Text == "\"")
 			{
-				signToken = Next(TokenType.Symbol, false, @"\-");
-			}
-			var isNegative = signToken?.Text == "-";
-
-			var token = Next(TokenType.Integer, throwOnError);
-			if (token == null)
-			{
-				return null;
-			}
-
-			if ((maxDigits > 1) && (token.Text.Length > maxDigits))
-			{
-				throw new SyntaxException($"({token.Line}:{token.Column}) INTEGER OVERFLOW");
-			}
-
-			var value = int.Parse(token.Text);
-			if (isNegative)
-			{
-				value = -value;
-			}
-			return value;
-		}
-
-		/// <summary>
-		/// Read a number off of the token stream.  The number can have a decimal point.
-		/// </summary>
-		/// <param name="throwOnError">If true, an exception will be thrown if an integer coule not be read.</param>
-		/// <returns>The number that was read.</returns>
-		/// <exception cref="UnexpectedTokenException">Throws an exception if an integer could not be read.</exception>
-		public double? NextNumber(bool throwOnError = true)
-		{
-			var signToken = Next(TokenType.Symbol, false, @"\+");
-			if (signToken == null)
-			{
-				signToken = Next(TokenType.Symbol, false, @"\-");
-			}
-
-			var integerToken = Next(TokenType.Integer, false);
-			var decimalToken = Next(TokenType.DecimalPoint, false);
-			string valueText;
-			if ((decimalToken == null) && (integerToken != null))
-			{
-				valueText = string.Concat(signToken?.Text ?? string.Empty, integerToken.Text, ".0");
-			}
-			else
-			{
-				var fractionToken = Next(TokenType.Integer, throwOnError);
-				if ((fractionToken == null) && (integerToken == null))
+				var stringToken = ReadRestOfString(token);
+				if (stringToken != null)
 				{
-					return null;
-				}
-
-				valueText = string.Concat(signToken?.Text ?? string.Empty, integerToken?.Text ?? string.Empty, ".", fractionToken?.Text ?? string.Empty);
-			}
-
-			// TODO: I don't really like how the "E" is typed here.
-			var exradToken = Next(TokenType.Word, false, @"E\d?");
-			if (exradToken != null)
-			{
-				var signText = string.Empty;
-				if (exradToken.Text == "E")
-				{
-					var exsignToken = Next(TokenType.Symbol, false, @"\+");
-					if (exsignToken == null)
-					{
-						exsignToken = Next(TokenType.Symbol, false, @"\-");
-					}
-					signText = exsignToken?.Text ?? string.Empty;
-				}
-
-				Token? powerToken = null;
-				if (!char.IsDigit(exradToken.Text.Last()))
-				{
-					powerToken = Next(TokenType.Integer, true);
-				}
-
-				valueText = string.Concat(valueText, exradToken.Text, signText, powerToken?.Text ?? string.Empty);
-			}
-
-			try
-			{
-				return double.Parse(valueText, System.Globalization.NumberStyles.Float);
-			}
-			catch (OverflowException ex)
-			{
-				throw new OverflowException($"'{valueText}' couldn't be converted.", ex);
-			}
-		}
-
-		/// <summary>
-		/// Get the next token off the stream, verifying the token type.
-		/// A null token will be returned if the type doesn't match, or optionally an exception will be thrown instead.
-		/// If a null token is returned, the reader will not be advanced to the next token.
-		/// </summary>
-		/// <param name="type">The type of token to retrieve.</param>
-		/// <param name="throwOnError">If true, an exception will be thrown if the type does not match.</param>
-		/// <param name="pattern">An optional regular expression pattern to match on the next token text.</param>
-		/// <returns>The token that was read.</returns>
-		/// <exception cref="UnexpectedTokenException">Throws an exception if the token type doesn't match what was expected.</exception>
-		public Token? Next(TokenType type, bool throwOnError = true, string? pattern = null)
-		{
-			var startPosition = TokenIndex;
-			var token = Next();
-			if ((token == null) || (token.Type != type) || ((pattern != null) && !Regex.IsMatch(token.Text, @"^" + pattern + @"$", RegexOptions.Singleline)))
-			{
-				if (throwOnError)
-				{
-					throw new UnexpectedTokenException(type, token);
-				}
-				else
-				{
-					TokenIndex = startPosition;
-					return null;
-				}
-			}
-			else
-			{
-				return token;
-			}
-		}
-
-		/// <summary>
-		/// Pull the next token off of the stream.
-		/// </summary>
-		/// <remarks>
-		/// No semantic analysis at this phase; that comes next.
-		/// </remarks>
-		/// <returns>The token that was read, or null at the end of the stream.</returns>
-		public Token? Next()
-		{
-			if (IsAtEnd)
-			{
-				return null;
-			}
-
-			var token = Read();
-
-			if (token?.Type == TokenType.Symbol)
-			{
-				if (token.Text == "\"")
-				{
-					var stringToken = ReadRestOfString(token);
-					if (stringToken != null)
-					{
-						return stringToken;
-					}
-					else
-					{
-						return token;
-					}
-				}
-				else if (token.Text == ",")
-				{
-					return new Token(TokenType.Comma, token);
-				}
-				else if (token.Text == ";")
-				{
-					return new Token(TokenType.Semicolon, token);
-				}
-				else if (token.Text == "(")
-				{
-					return new Token(TokenType.OpenParenthesis, token);
-				}
-				else if (token.Text == ")")
-				{
-					return new Token(TokenType.CloseParenthesis, token);
-				}
-				else if (token.Text == ".")
-				{
-					return new Token(TokenType.DecimalPoint, token);
+					return stringToken;
 				}
 				else
 				{
 					return token;
 				}
 			}
-			else if (token?.Type == TokenType.Word)
+			else if (token.Text == ",")
 			{
-				if (token.Text.Length == 1)
+				return new Token(TokenType.Comma, token);
+			}
+			else if (token.Text == ";")
+			{
+				return new Token(TokenType.Semicolon, token);
+			}
+			else if (token.Text == "(")
+			{
+				return new Token(TokenType.OpenParenthesis, token);
+			}
+			else if (token.Text == ")")
+			{
+				return new Token(TokenType.CloseParenthesis, token);
+			}
+			else if (token.Text == ".")
+			{
+				return new Token(TokenType.DecimalPoint, token);
+			}
+			else
+			{
+				return token;
+			}
+		}
+		else if (token?.Type == TokenType.Word)
+		{
+			if (token.Text.Length == 1)
+			{
+				var nextToken = Peek();
+				if ((nextToken?.Type == TokenType.Symbol) && (nextToken.Text == "$"))
 				{
-					var nextToken = Peek();
-					if ((nextToken?.Type == TokenType.Symbol) && (nextToken.Text == "$"))
+					Read();  // Read off the $.
+					return new Token(TokenType.Word, new[] { token, nextToken });
+				}
+				else
+				{
+					nextToken = Peek();
+					if ((nextToken?.Type == TokenType.Integer) && (nextToken.Text.Length == 1))
 					{
-						Read();  // Read off the $.
+						Read();  // Read off the digit.
+						// It's a numeric variable with a letter followed by a digit.
 						return new Token(TokenType.Word, new[] { token, nextToken });
 					}
 					else
 					{
-						nextToken = Peek();
-						if ((nextToken?.Type == TokenType.Integer) && (nextToken.Text.Length == 1))
-						{
-							Read();  // Read off the digit.
-							// It's a numeric variable with a letter followed by a digit.
-							return new Token(TokenType.Word, new[] { token, nextToken });
-						}
-						else
-						{
-							// It's a numeric variable with just a single letter.
-							return new Token(TokenType.Word, new[] { token });
-						}
+						// It's a numeric variable with just a single letter.
+						return new Token(TokenType.Word, new[] { token });
 					}
-				}
-				else
-				{
-					return token;
 				}
 			}
 			else
@@ -274,68 +269,72 @@ namespace ECMABasic.Core
 				return token;
 			}
 		}
-
-		private Token? ReadRestOfString(Token start)
+		else
 		{
-			var startIndex = TokenIndex;
-			List<Token> stringTokens = new() { start };
-
-			while (true)
-			{
-				var token = Read();
-				if ((token == null) || (token.Type == TokenType.EndOfLine))
-				{
-					// Rewind.
-					TokenIndex = startIndex;
-					return null;
-				}
-
-				stringTokens.Add(token);
-				if (token.Type == TokenType.Symbol)
-				{
-					if (token.Text == "\"")
-					{
-						break;
-					}
-				}
-			}
-
-			return new Token(TokenType.String, stringTokens);
-		}
-
-		private Token? Read()
-		{
-			if (IsAtEnd)
-			{
-				return null;
-			}
-
-			var token = _tokens[TokenIndex];
-			TokenIndex++;
 			return token;
 		}
+	}
 
-		public Token? Peek()
+	private Token? ReadRestOfString(Token start)
+	{
+		var startIndex = TokenIndex;
+		List<Token> stringTokens = new() { start };
+
+		while (true)
 		{
-			if (IsAtEnd)
+			var token = Read();
+			if ((token == null) || (token.Type == TokenType.EndOfLine))
 			{
+				// Rewind.
+				TokenIndex = startIndex;
 				return null;
 			}
-			return _tokens[TokenIndex];
-		}
 
-		public void Seek(int index)
-		{
-			TokenIndex = index;
-		}
-
-		public void Rewind()
-		{
-			if (TokenIndex == 0)
+			stringTokens.Add(token);
+			if (token.Type == TokenType.Symbol)
 			{
-				return;
+				if (token.Text == "\"")
+				{
+					break;
+				}
 			}
-			TokenIndex--;
 		}
+
+		return new Token(TokenType.String, stringTokens);
+	}
+
+	private Token? Read()
+	{
+		if (IsAtEnd)
+		{
+			return null;
+		}
+
+		var token = _tokens[TokenIndex];
+		TokenIndex++;
+		return token;
+	}
+
+	public Token? Peek()
+	{
+		if (IsAtEnd)
+		{
+			return null;
+		}
+		return _tokens[TokenIndex];
+	}
+
+	public void Seek(int index)
+	{
+		TokenIndex = index;
+	}
+
+	public void Rewind()
+	{
+		if (TokenIndex == 0)
+		{
+			return;
+		}
+		TokenIndex--;
 	}
 }

--- a/src/ECMABasic.Core/Configuration/IBasicConfiguration.cs
+++ b/src/ECMABasic.Core/Configuration/IBasicConfiguration.cs
@@ -1,50 +1,49 @@
-﻿namespace ECMABasic.Core.Configuration
+﻿namespace ECMABasic.Core.Configuration;
+
+public interface IBasicConfiguration
 {
-	public interface IBasicConfiguration
-	{
-		/// <summary>
-		/// The maximum number of characters allowed on a program line, including the line number and all whitespace.
-		/// </summary>
-		public int MaxLineLength { get; }
+	/// <summary>
+	/// The maximum number of characters allowed on a program line, including the line number and all whitespace.
+	/// </summary>
+	public int MaxLineLength { get; }
 
-		/// <summary>
-		/// The maximum number of characters allowed to be assigned to a string.
-		/// </summary>
-		public int MaxStringLength { get; }
+	/// <summary>
+	/// The maximum number of characters allowed to be assigned to a string.
+	/// </summary>
+	public int MaxStringLength { get; }
 
-		/// <summary>
-		/// The total width of the terminal.
-		/// </summary>
-		public int TerminalWidth { get; }
+	/// <summary>
+	/// The total width of the terminal.
+	/// </summary>
+	public int TerminalWidth { get; }
 
-		/// <summary>
-		/// The number of columns to split the terminal into.
-		/// </summary>
-		public int NumTerminalColumns { get; }
+	/// <summary>
+	/// The number of columns to split the terminal into.
+	/// </summary>
+	public int NumTerminalColumns { get; }
 
-		/// <summary>
-		/// The width of a single terminal column.
-		/// </summary>
-		public int TerminalColumnWidth { get; }
+	/// <summary>
+	/// The width of a single terminal column.
+	/// </summary>
+	public int TerminalColumnWidth { get; }
 
-		/// <summary>
-		/// The total number of digits allowed in a line number.
-		/// </summary>
-		public int MaxLineNumberDigits { get; }
+	/// <summary>
+	/// The total number of digits allowed in a line number.
+	/// </summary>
+	public int MaxLineNumberDigits { get; }
 
-		/// <summary>
-		/// The number of significant decimal digits printed in numeric representations.
-		/// </summary>
-		public int SignificanceWidth { get; }
+	/// <summary>
+	/// The number of significant decimal digits printed in numeric representations.
+	/// </summary>
+	public int SignificanceWidth { get; }
 
-		/// <summary>
-		/// The number of digits printed in the exrad component of a numeric representation.
-		/// </summary>
-		public int ExradWidth { get; }
+	/// <summary>
+	/// The number of digits printed in the exrad component of a numeric representation.
+	/// </summary>
+	public int ExradWidth { get; }
 
-		/// <summary>
-		/// The highest possible line number.
-		/// </summary>
-		public int MaxLineNumber { get; }
-	}
+	/// <summary>
+	/// The highest possible line number.
+	/// </summary>
+	public int MaxLineNumber { get; }
 }

--- a/src/ECMABasic.Core/Configuration/MinimalBasicConfigDefaults.cs
+++ b/src/ECMABasic.Core/Configuration/MinimalBasicConfigDefaults.cs
@@ -1,13 +1,12 @@
-﻿namespace ECMABasic.Core.Configuration
+﻿namespace ECMABasic.Core.Configuration;
+
+internal class MinimalBasicConfigDefaults
 {
-	internal class MinimalBasicConfigDefaults
-	{
-		public const int MAX_LINE_LENGTH = 72;
-		public const int MAX_STRING_LENGTH = 18;
-		public const int TERMINAL_WIDTH = 80;
-		public const int NUM_TERMINAL_COLUMNS = 5;
-		public const int MAX_LINE_NUMBER_DIGITS = 4;
-		public const int SIGNIFICANCE_WIDTH = 6;
-		public const int EXRAD_WIDTH = 2;
-	}
+	public const int MAX_LINE_LENGTH = 72;
+	public const int MAX_STRING_LENGTH = 18;
+	public const int TERMINAL_WIDTH = 80;
+	public const int NUM_TERMINAL_COLUMNS = 5;
+	public const int MAX_LINE_NUMBER_DIGITS = 4;
+	public const int SIGNIFICANCE_WIDTH = 6;
+	public const int EXRAD_WIDTH = 2;
 }

--- a/src/ECMABasic.Core/Configuration/MinimalBasicConfiguration.cs
+++ b/src/ECMABasic.Core/Configuration/MinimalBasicConfiguration.cs
@@ -1,72 +1,71 @@
 ﻿using Microsoft.Extensions.Configuration;
 using System;
 
-namespace ECMABasic.Core.Configuration
+namespace ECMABasic.Core.Configuration;
+
+/// <summary>
+/// Contains global configuration settings to control everything.
+/// </summary>
+public class MinimalBasicConfiguration : IBasicConfiguration
 {
-	/// <summary>
-	/// Contains global configuration settings to control everything.
-	/// </summary>
-	public class MinimalBasicConfiguration : IBasicConfiguration
+	private MinimalBasicConfiguration()
 	{
-		private MinimalBasicConfiguration()
-		{
-			var config = new ConfigurationBuilder()
-				.AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
-				.Build();
+		var config = new ConfigurationBuilder()
+			.AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
+			.Build();
 
-			MaxLineLength = GetValueOrDefault(config, "maxLineLength", MinimalBasicConfigDefaults.MAX_LINE_LENGTH);
-			MaxStringLength = GetValueOrDefault(config, "maxStringLength", MinimalBasicConfigDefaults.MAX_STRING_LENGTH);
-			TerminalWidth = GetValueOrDefault(config, "terminalWidth", MinimalBasicConfigDefaults.TERMINAL_WIDTH);
-			NumTerminalColumns = GetValueOrDefault(config, "numTerminalColumns", MinimalBasicConfigDefaults.NUM_TERMINAL_COLUMNS);
-			MaxLineNumberDigits = GetValueOrDefault(config, "maxLineNumberDigits", MinimalBasicConfigDefaults.MAX_LINE_NUMBER_DIGITS);
-			SignificanceWidth = GetValueOrDefault(config, "significanceWidth", MinimalBasicConfigDefaults.SIGNIFICANCE_WIDTH);
-			ExradWidth = GetValueOrDefault(config, "exradWidth", MinimalBasicConfigDefaults.EXRAD_WIDTH);
+		MaxLineLength = GetValueOrDefault(config, "maxLineLength", MinimalBasicConfigDefaults.MAX_LINE_LENGTH);
+		MaxStringLength = GetValueOrDefault(config, "maxStringLength", MinimalBasicConfigDefaults.MAX_STRING_LENGTH);
+		TerminalWidth = GetValueOrDefault(config, "terminalWidth", MinimalBasicConfigDefaults.TERMINAL_WIDTH);
+		NumTerminalColumns = GetValueOrDefault(config, "numTerminalColumns", MinimalBasicConfigDefaults.NUM_TERMINAL_COLUMNS);
+		MaxLineNumberDigits = GetValueOrDefault(config, "maxLineNumberDigits", MinimalBasicConfigDefaults.MAX_LINE_NUMBER_DIGITS);
+		SignificanceWidth = GetValueOrDefault(config, "significanceWidth", MinimalBasicConfigDefaults.SIGNIFICANCE_WIDTH);
+		ExradWidth = GetValueOrDefault(config, "exradWidth", MinimalBasicConfigDefaults.EXRAD_WIDTH);
+	}
+
+	public static IBasicConfiguration Instance { get; } = new MinimalBasicConfiguration();
+
+	public int MaxLineLength { get; }
+
+	public int MaxStringLength { get; }
+
+	public int TerminalWidth { get; }
+
+	public int NumTerminalColumns { get; }
+
+	public int TerminalColumnWidth
+	{
+		get
+		{
+			return TerminalWidth / NumTerminalColumns;
 		}
+	}
 
-		public static IBasicConfiguration Instance { get; } = new MinimalBasicConfiguration();
+	public int MaxLineNumberDigits { get; }
 
-		public int MaxLineLength { get; }
+	public int SignificanceWidth { get; }
 
-		public int MaxStringLength { get; }
+	public int ExradWidth { get; }
 
-		public int TerminalWidth { get; }
-
-		public int NumTerminalColumns { get; }
-
-		public int TerminalColumnWidth
+	public int MaxLineNumber
+	{
+		get
 		{
-			get
-			{
-				return TerminalWidth / NumTerminalColumns;
-			}
+			return (int)(Math.Pow(10, MaxLineNumberDigits) - 1);
 		}
+	}
 
-		public int MaxLineNumberDigits { get; }
-
-		public int SignificanceWidth { get; }
-
-		public int ExradWidth { get; }
-
-		public int MaxLineNumber
+	private T GetValueOrDefault<T>(IConfiguration config, string key, T defaultValue)
+	{
+		var section = config.GetSection(key);
+		var value = section.Value;
+		if (value == null)
 		{
-			get
-			{
-				return (int)(Math.Pow(10, MaxLineNumberDigits) - 1);
-			}
+			return defaultValue;
 		}
-
-		private T GetValueOrDefault<T>(IConfiguration config, string key, T defaultValue)
+		else
 		{
-			var section = config.GetSection(key);
-			var value = section.Value;
-			if (value == null)
-			{
-				return defaultValue;
-			}
-			else
-			{
-				return (T)Convert.ChangeType(value, typeof(T));
-			}
+			return (T)Convert.ChangeType(value, typeof(T));
 		}
 	}
 }

--- a/src/ECMABasic.Core/DataPointer.cs
+++ b/src/ECMABasic.Core/DataPointer.cs
@@ -1,8 +1,7 @@
-﻿namespace ECMABasic.Core
+﻿namespace ECMABasic.Core;
+
+public class DataPointer
 {
-	public class DataPointer
-	{
-		public int LineIndex { get; set; }
-		public int DatumIndex { get; set; }
-	}
+	public int LineIndex { get; set; }
+	public int DatumIndex { get; set; }
 }

--- a/src/ECMABasic.Core/EnvironmentBase.cs
+++ b/src/ECMABasic.Core/EnvironmentBase.cs
@@ -3,163 +3,162 @@ using ECMABasic.Core.Exceptions;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace ECMABasic.Core
+namespace ECMABasic.Core;
+
+public abstract class EnvironmentBase : IEnvironment
 {
-	public abstract class EnvironmentBase : IEnvironment
+	private readonly Dictionary<string, string> _stringVariables = new();
+	private readonly Dictionary<string, double> _numericVariables = new();
+	private readonly Stack<ICallStackContext> _callStack = new();
+	private readonly DataPointer _dataPointer = new();
+
+	private readonly IBasicConfiguration _config;
+
+	public EnvironmentBase(Interpreter? interpreter = null, IBasicConfiguration? config = null)
 	{
-		private readonly Dictionary<string, string> _stringVariables = new();
-		private readonly Dictionary<string, double> _numericVariables = new();
-		private readonly Stack<ICallStackContext> _callStack = new();
-		private readonly DataPointer _dataPointer = new();
+		Interpreter = interpreter ?? new Interpreter();
+		_config = config ?? MinimalBasicConfiguration.Instance;
+		Program = new Program();
+	}
 
-		private readonly IBasicConfiguration _config;
+	public Interpreter Interpreter { get; }
 
-		public EnvironmentBase(Interpreter? interpreter = null, IBasicConfiguration? config = null)
+	/// <summary>
+	/// The line number currently being executed.
+	/// </summary>
+	public int CurrentLineNumber { get; set; }
+
+	public abstract int TerminalRow { get; set; }
+
+	public abstract int TerminalColumn { get; set; }
+
+	public Program Program { get; private set; }
+
+	public abstract string ReadLine();
+
+	public abstract void Print(string text);
+
+	public abstract void PrintLine(string text = "");
+
+	public abstract void ReportError(string message);
+
+	public string GetStringVariableValue(string variableName)
+	{
+		// TODO: Validate variable name?
+		if (!_stringVariables.ContainsKey(variableName))
 		{
-			Interpreter = interpreter ?? new Interpreter();
-			_config = config ?? MinimalBasicConfiguration.Instance;
-			Program = new Program();
+			var value = string.Empty;
+			SetStringVariableValue(variableName, value);
+			return value;
 		}
-
-		public Interpreter Interpreter { get; }
-
-		/// <summary>
-		/// The line number currently being executed.
-		/// </summary>
-		public int CurrentLineNumber { get; set; }
-
-		public abstract int TerminalRow { get; set; }
-
-		public abstract int TerminalColumn { get; set; }
-
-		public Program Program { get; private set; }
-
-		public abstract string ReadLine();
-
-		public abstract void Print(string text);
-
-		public abstract void PrintLine(string text = "");
-
-		public abstract void ReportError(string message);
-
-		public string GetStringVariableValue(string variableName)
+		return _stringVariables[variableName];
+	}
+	
+	public void SetStringVariableValue(string variableName, string value)
+	{
+		// TODO: Validate variable name?
+		if (value.Length > _config.MaxStringLength)
 		{
-			// TODO: Validate variable name?
-			if (!_stringVariables.ContainsKey(variableName))
-			{
-				var value = string.Empty;
-				SetStringVariableValue(variableName, value);
-				return value;
-			}
-			return _stringVariables[variableName];
+			throw ExceptionFactory.StringOverflow(CurrentLineNumber);
 		}
-		
-		public void SetStringVariableValue(string variableName, string value)
+		if (!variableName.EndsWith("$"))
 		{
-			// TODO: Validate variable name?
-			if (value.Length > _config.MaxStringLength)
-			{
-				throw ExceptionFactory.StringOverflow(CurrentLineNumber);
-			}
-			if (!variableName.EndsWith("$"))
-			{
-				throw ExceptionFactory.MixedStringsAndNumbers(CurrentLineNumber);
-			}
-			_stringVariables[variableName] = value;
+			throw ExceptionFactory.MixedStringsAndNumbers(CurrentLineNumber);
 		}
+		_stringVariables[variableName] = value;
+	}
 
-		public double GetNumericVariableValue(string variableName)
+	public double GetNumericVariableValue(string variableName)
+	{
+		// TODO: Validate variable name?
+		if (!_numericVariables.ContainsKey(variableName))
 		{
-			// TODO: Validate variable name?
-			if (!_numericVariables.ContainsKey(variableName))
-			{
-				var value = 0;
-				SetNumericVariableValue(variableName, value);
-				return value;
-			}
-			return _numericVariables[variableName];
+			var value = 0;
+			SetNumericVariableValue(variableName, value);
+			return value;
 		}
+		return _numericVariables[variableName];
+	}
 
-		public void SetNumericVariableValue(string variableName, double value)
+	public void SetNumericVariableValue(string variableName, double value)
+	{
+		// TODO: Validate variable name?
+		if (variableName.EndsWith("$"))
 		{
-			// TODO: Validate variable name?
-			if (variableName.EndsWith("$"))
-			{
-				throw ExceptionFactory.MixedStringsAndNumbers(CurrentLineNumber);
-			}
-			_numericVariables[variableName] = value;
+			throw ExceptionFactory.MixedStringsAndNumbers(CurrentLineNumber);
 		}
+		_numericVariables[variableName] = value;
+	}
 
-		public void Clear()
-		{
-			Program.Clear();
-			_numericVariables.Clear();
-			_stringVariables.Clear();
-			CurrentLineNumber = 0;
-		}
+	public void Clear()
+	{
+		Program.Clear();
+		_numericVariables.Clear();
+		_stringVariables.Clear();
+		CurrentLineNumber = 0;
+	}
 
-		public bool ValidateLineNumber(int lineNumber, bool throwsIfMissing = false)
+	public bool ValidateLineNumber(int lineNumber, bool throwsIfMissing = false)
+	{
+		if (!Program.Any(x => x.LineNumber == lineNumber))
 		{
-			if (!Program.Any(x => x.LineNumber == lineNumber))
+			if (throwsIfMissing)
 			{
-				if (throwsIfMissing)
-				{
-					throw ExceptionFactory.UndefinedLineNumber(lineNumber, CurrentLineNumber);
-				}
-				else
-				{
-					return false;
-				}
+				throw ExceptionFactory.UndefinedLineNumber(lineNumber, CurrentLineNumber);
 			}
 			else
 			{
-				return true;
+				return false;
 			}
 		}
-
-		public void PushCallStack(ICallStackContext context)
+		else
 		{
-			_callStack.Push(context);
+			return true;
 		}
+	}
 
-		public ICallStackContext? PopCallStack()
+	public void PushCallStack(ICallStackContext context)
+	{
+		_callStack.Push(context);
+	}
+
+	public ICallStackContext? PopCallStack()
+	{
+		if (_callStack.Count == 0)
 		{
-			if (_callStack.Count == 0)
-			{
-				return null;
-			}
-			return _callStack.Pop();
+			return null;
 		}
+		return _callStack.Pop();
+	}
 
-		public abstract void CheckForStopRequest();
+	public abstract void CheckForStopRequest();
 
-		public bool LoadFile(string filename)
+	public bool LoadFile(string filename)
+	{
+		Program.Clear();
+		return Interpreter.InterpretProgramFromFile(this, filename);
+	}
+
+	public IExpression ReadData()
+	{
+		var data = Program.GetDataLine(_dataPointer.LineIndex);
+		if (data == null)
 		{
-			Program.Clear();
-			return Interpreter.InterpretProgramFromFile(this, filename);
+			throw ExceptionFactory.OutOfData(CurrentLineNumber);
 		}
-
-		public IExpression ReadData()
+		var datum = data.Datums[_dataPointer.DatumIndex];
+		_dataPointer.DatumIndex++;
+		if (_dataPointer.DatumIndex >= data.Datums.Count)
 		{
-			var data = Program.GetDataLine(_dataPointer.LineIndex);
-			if (data == null)
-			{
-				throw ExceptionFactory.OutOfData(CurrentLineNumber);
-			}
-			var datum = data.Datums[_dataPointer.DatumIndex];
-			_dataPointer.DatumIndex++;
-			if (_dataPointer.DatumIndex >= data.Datums.Count)
-			{
-				_dataPointer.DatumIndex = 0;
-				_dataPointer.LineIndex++;
-			}
-			return datum;
-		}
-
-		public void ResetDataPointer()
-		{
-			_dataPointer.LineIndex = 0;
 			_dataPointer.DatumIndex = 0;
+			_dataPointer.LineIndex++;
 		}
+		return datum;
+	}
+
+	public void ResetDataPointer()
+	{
+		_dataPointer.LineIndex = 0;
+		_dataPointer.DatumIndex = 0;
 	}
 }

--- a/src/ECMABasic.Core/Exceptions/ExceptionFactory.cs
+++ b/src/ECMABasic.Core/Exceptions/ExceptionFactory.cs
@@ -1,163 +1,162 @@
 ﻿using ECMABasic.Core.Exceptions;
 using System;
 
-namespace ECMABasic.Core
+namespace ECMABasic.Core;
+
+public static class ExceptionFactory
 {
-	public static class ExceptionFactory
+	public static Exception Syntax()
 	{
-		public static Exception Syntax()
-		{
-			return new SyntaxException("SYNTAX ERROR");
-		}
+		return new SyntaxException("SYNTAX ERROR");
+	}
 
-		public static Exception ProgramStop(int? lineNumber)
-		{
-			return new ProgramStopException(lineNumber);
-		}
+	public static Exception ProgramStop(int? lineNumber)
+	{
+		return new ProgramStopException(lineNumber);
+	}
 
-		public static Exception ProgramEnd(int? lineNumber)
-		{
-			return new ProgramEndException(lineNumber);
-		}
+	public static Exception ProgramEnd(int? lineNumber)
+	{
+		return new ProgramEndException(lineNumber);
+	}
 
-		public static Exception NoEndInstruction()
-		{
-			return new NoEndInstructionException();
-		}
+	public static Exception NoEndInstruction()
+	{
+		return new NoEndInstructionException();
+	}
 
-		public static Exception EndIsNotLast(int? lineNumber)
-		{
-			return new SyntaxException("END IS NOT LAST", lineNumber);
-		}
+	public static Exception EndIsNotLast(int? lineNumber)
+	{
+		return new SyntaxException("END IS NOT LAST", lineNumber);
+	}
 
-		public static Exception LineNumberExpected()
-		{
-			return new SyntaxException("EXPECTED A LINE NUMBER");
-		}
+	public static Exception LineNumberExpected()
+	{
+		return new SyntaxException("EXPECTED A LINE NUMBER");
+	}
 
-		public static Exception LineTooLong(int tooLongBy, int? lineNumber = null)
-		{
-			return new SyntaxException($"LINE IS TOO LONG BY {tooLongBy} CHARACTERS", lineNumber);
-		}
+	public static Exception LineTooLong(int tooLongBy, int? lineNumber = null)
+	{
+		return new SyntaxException($"LINE IS TOO LONG BY {tooLongBy} CHARACTERS", lineNumber);
+	}
 
-		public static Exception UndefinedFunction(int? lineNumber = null)
-		{
-			return new SyntaxException("UNDEFINED FUNCTION", lineNumber);
-		}
+	public static Exception UndefinedFunction(int? lineNumber = null)
+	{
+		return new SyntaxException("UNDEFINED FUNCTION", lineNumber);
+	}
 
-		public static Exception NotAllowedInProgram(int? lineNumber = null)
-		{
-			return new RuntimeException("NOT ALLOWED IN PROGRAM", lineNumber);
-		}
+	public static Exception NotAllowedInProgram(int? lineNumber = null)
+	{
+		return new RuntimeException("NOT ALLOWED IN PROGRAM", lineNumber);
+	}
 
-		public static Exception OnlyAllowedInProgram(int? lineNumber = null)
-		{
-			return new RuntimeException("ONLY ALLOWED BE IN PROGRAM", lineNumber);
-		}
+	public static Exception OnlyAllowedInProgram(int? lineNumber = null)
+	{
+		return new RuntimeException("ONLY ALLOWED BE IN PROGRAM", lineNumber);
+	}
 
-		public static Exception UndefinedLineNumber(int testLineNumber, int? lineNumber = null)
-		{
-			return new RuntimeException($"UNDEFINED LINE NUMBER {testLineNumber}", lineNumber);
-		}
+	public static Exception UndefinedLineNumber(int testLineNumber, int? lineNumber = null)
+	{
+		return new RuntimeException($"UNDEFINED LINE NUMBER {testLineNumber}", lineNumber);
+	}
 
-		public static Exception LineNumberOutOfRange(int testLineNumber, int? lineNumber = null)
-		{
-			return new RuntimeException($"LINE NUMBER {testLineNumber} OUT OF RANGE", lineNumber);
-		}
+	public static Exception LineNumberOutOfRange(int testLineNumber, int? lineNumber = null)
+	{
+		return new RuntimeException($"LINE NUMBER {testLineNumber} OUT OF RANGE", lineNumber);
+	}
 
-		public static Exception ForWithoutNext(int? lineNumber = null)
-		{
-			return new SyntaxException("FOR WITHOUT NEXT", lineNumber);
-		}
+	public static Exception ForWithoutNext(int? lineNumber = null)
+	{
+		return new SyntaxException("FOR WITHOUT NEXT", lineNumber);
+	}
 
-		public static Exception NextWithoutFor(int? lineNumber = null)
-		{
-			return new SyntaxException("NEXT WITHOUT FOR", lineNumber);
-		}
+	public static Exception NextWithoutFor(int? lineNumber = null)
+	{
+		return new SyntaxException("NEXT WITHOUT FOR", lineNumber);
+	}
 
-		public static Exception ForUsingPreviousControlVariable(int? lineNumber = null)
-		{
-			return new SyntaxException("FOR USING PREVIOUS CONTROL-VARIABLE", lineNumber);
-		}
+	public static Exception ForUsingPreviousControlVariable(int? lineNumber = null)
+	{
+		return new SyntaxException("FOR USING PREVIOUS CONTROL-VARIABLE", lineNumber);
+	}
 
-		public static Exception ControlTransferIntoForBlock(int? lineNumber = null)
-		{
-			return new RuntimeException("CONTROL TRANSFER INTO FOR-BLOCK", lineNumber);
-		}
+	public static Exception ControlTransferIntoForBlock(int? lineNumber = null)
+	{
+		return new RuntimeException("CONTROL TRANSFER INTO FOR-BLOCK", lineNumber);
+	}
 
-		public static Exception ReturnWithoutGosub(int? lineNumber = null)
-		{
-			return new RuntimeException("RETURN WITHOUT GOSUB", lineNumber);
-		}
+	public static Exception ReturnWithoutGosub(int? lineNumber = null)
+	{
+		return new RuntimeException("RETURN WITHOUT GOSUB", lineNumber);
+	}
 
-		public static Exception MixedStringsAndNumbers(int? lineNumber = null)
-		{
-			return new SyntaxException("MIXED STRINGS AND NUMBERS", lineNumber);
-		}
+	public static Exception MixedStringsAndNumbers(int? lineNumber = null)
+	{
+		return new SyntaxException("MIXED STRINGS AND NUMBERS", lineNumber);
+	}
 
-		public static Exception OutOfData(int? lineNumber = null)
-		{
-			return new RuntimeException("OUT OF DATA", lineNumber);
-		}
+	public static Exception OutOfData(int? lineNumber = null)
+	{
+		return new RuntimeException("OUT OF DATA", lineNumber);
+	}
 
-		public static Exception ExpectedConditionalExpression(int? lineNumber = null)
-		{
-			return new SyntaxException("EXPECTED A CONDITIONAL EXPRESSION", lineNumber);
-		}
+	public static Exception ExpectedConditionalExpression(int? lineNumber = null)
+	{
+		return new SyntaxException("EXPECTED A CONDITIONAL EXPRESSION", lineNumber);
+	}
 
-		public static Exception ExpectedStringExpression(int? lineNumber = null)
-		{
-			return new SyntaxException("EXPECTED A STRING EXPRESSION", lineNumber);
-		}
+	public static Exception ExpectedStringExpression(int? lineNumber = null)
+	{
+		return new SyntaxException("EXPECTED A STRING EXPRESSION", lineNumber);
+	}
 
-		public static Exception ExpectedNumericExpression(int? lineNumber = null)
-		{
-			return new SyntaxException("EXPECTED A NUMERIC EXPRESSION", lineNumber);
-		}
+	public static Exception ExpectedNumericExpression(int? lineNumber = null)
+	{
+		return new SyntaxException("EXPECTED A NUMERIC EXPRESSION", lineNumber);
+	}
 
-		public static Exception ExpectedNumericVariable(int? lineNumber = null)
-		{
-			return new SyntaxException("EXPECTED A NUMERIC VARIABLE", lineNumber);
-		}
+	public static Exception ExpectedNumericVariable(int? lineNumber = null)
+	{
+		return new SyntaxException("EXPECTED A NUMERIC VARIABLE", lineNumber);
+	}
 
-		public static Exception ExpectedVariable(int? lineNumber = null)
-		{
-			return new SyntaxException("EXPECTED A VARIABLE", lineNumber);
-		}
+	public static Exception ExpectedVariable(int? lineNumber = null)
+	{
+		return new SyntaxException("EXPECTED A VARIABLE", lineNumber);
+	}
 
-		public static Exception ExpectedData(int? lineNumber = null)
-		{
-			return new RuntimeException("EXPECTED A DATA STATEMENT", lineNumber);
-		}
+	public static Exception ExpectedData(int? lineNumber = null)
+	{
+		return new RuntimeException("EXPECTED A DATA STATEMENT", lineNumber);
+	}
 
-		public static Exception StringOverflow(int? lineNumber = null)
-		{
-			return new RuntimeException("STRING OVERFLOW", lineNumber);
-		}
+	public static Exception StringOverflow(int? lineNumber = null)
+	{
+		return new RuntimeException("STRING OVERFLOW", lineNumber);
+	}
 
-		public static Exception ArgumentCountMismatch(int? lineNumber = null)
-		{
-			return new SyntaxException("ARGUMENT COUNT MISMATCH", lineNumber);
-		}
+	public static Exception ArgumentCountMismatch(int? lineNumber = null)
+	{
+		return new SyntaxException("ARGUMENT COUNT MISMATCH", lineNumber);
+	}
 
-		public static Exception ArgumentTypeMismatch(int? lineNumber = null)
-		{
-			return new SyntaxException("ARGUMENT TYPE MISMATCH", lineNumber);
-		}
+	public static Exception ArgumentTypeMismatch(int? lineNumber = null)
+	{
+		return new SyntaxException("ARGUMENT TYPE MISMATCH", lineNumber);
+	}
 
-		public static Exception IllegalOperator(int? lineNumber = null)
-		{
-			return new SyntaxException("ILLEGAL OPERATOR", lineNumber);
-		}
+	public static Exception IllegalOperator(int? lineNumber = null)
+	{
+		return new SyntaxException("ILLEGAL OPERATOR", lineNumber);
+	}
 
-		public static Exception IllegalFormula(int? lineNumber = null)
-		{
-			return new SyntaxException("ILLEGAL FORMULA", lineNumber);
-		}
+	public static Exception IllegalFormula(int? lineNumber = null)
+	{
+		return new SyntaxException("ILLEGAL FORMULA", lineNumber);
+	}
 
-		public static Exception IndexOutOfRange(int? lineNumber = null)
-		{
-			return new RuntimeException("INDEX OUT OF RANGE", lineNumber);
-		}
+	public static Exception IndexOutOfRange(int? lineNumber = null)
+	{
+		return new RuntimeException("INDEX OUT OF RANGE", lineNumber);
 	}
 }

--- a/src/ECMABasic.Core/Exceptions/NoEndInstructionException.cs
+++ b/src/ECMABasic.Core/Exceptions/NoEndInstructionException.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 
-namespace ECMABasic.Core.Exceptions
+namespace ECMABasic.Core.Exceptions;
+
+internal class NoEndInstructionException : SyntaxException
 {
-	internal class NoEndInstructionException : SyntaxException
+	public NoEndInstructionException()
+		: base("NO END INSTRUCTION")
 	{
-		public NoEndInstructionException()
-			: base("NO END INSTRUCTION")
-		{
-		}
 	}
 }

--- a/src/ECMABasic.Core/Exceptions/ProgramEndException.cs
+++ b/src/ECMABasic.Core/Exceptions/ProgramEndException.cs
@@ -1,10 +1,9 @@
-﻿namespace ECMABasic.Core.Exceptions
+﻿namespace ECMABasic.Core.Exceptions;
+
+internal class ProgramEndException : RuntimeException
 {
-	internal class ProgramEndException : RuntimeException
+	public ProgramEndException(int? lineNumber)
+		: base("END", lineNumber)
 	{
-		public ProgramEndException(int? lineNumber)
-			: base("END", lineNumber)
-		{
-		}
 	}
 }

--- a/src/ECMABasic.Core/Exceptions/ProgramStopException.cs
+++ b/src/ECMABasic.Core/Exceptions/ProgramStopException.cs
@@ -1,10 +1,9 @@
-﻿namespace ECMABasic.Core.Exceptions
+﻿namespace ECMABasic.Core.Exceptions;
+
+public class ProgramStopException : RuntimeException
 {
-	public class ProgramStopException : RuntimeException
+	public ProgramStopException(int? lineNumber)
+		: base($"STOPPED", lineNumber)
 	{
-		public ProgramStopException(int? lineNumber)
-			: base($"STOPPED", lineNumber)
-		{
-		}
 	}
 }

--- a/src/ECMABasic.Core/Exceptions/RuntimeException.cs
+++ b/src/ECMABasic.Core/Exceptions/RuntimeException.cs
@@ -1,17 +1,16 @@
 ﻿using System;
 
-namespace ECMABasic.Core.Exceptions
-{
-	public class RuntimeException : Exception
-	{
-		public RuntimeException(string message, int? line = null)
-			: base(string.Concat($"% {message.ToUpper()}", (line.HasValue ? $" IN LINE {line}" : string.Empty)))
-		{
-			RootMessage = message;
-			LineNumber = line;
-		}
+namespace ECMABasic.Core.Exceptions;
 
-		public string RootMessage { get; }
-		public int? LineNumber { get; }
+public class RuntimeException : Exception
+{
+	public RuntimeException(string message, int? line = null)
+		: base(string.Concat($"% {message.ToUpper()}", (line.HasValue ? $" IN LINE {line}" : string.Empty)))
+	{
+		RootMessage = message;
+		LineNumber = line;
 	}
+
+	public string RootMessage { get; }
+	public int? LineNumber { get; }
 }

--- a/src/ECMABasic.Core/Exceptions/SyntaxException.cs
+++ b/src/ECMABasic.Core/Exceptions/SyntaxException.cs
@@ -1,24 +1,23 @@
 ﻿using System;
 
-namespace ECMABasic.Core.Exceptions
+namespace ECMABasic.Core.Exceptions;
+
+public class SyntaxException : Exception
 {
-	public class SyntaxException : Exception
+	public SyntaxException(string message, int? line = null)
+		: base(string.Concat($"? {message.ToUpper()}", (line.HasValue ? $" IN LINE {line}" : string.Empty)))
 	{
-		public SyntaxException(string message, int? line = null)
-			: base(string.Concat($"? {message.ToUpper()}", (line.HasValue ? $" IN LINE {line}" : string.Empty)))
-		{
-			RootMessage = message.ToUpper();
-			LineNumber = line;
-		}
-
-		public SyntaxException(SyntaxException ex, int? line = null)
-			: base(string.Concat(ex.Message, (line.HasValue ? $" IN LINE {line}" : string.Empty)))
-		{
-			RootMessage = ex.RootMessage.ToUpper();
-			LineNumber = line;
-		}
-
-		public string RootMessage { get; }
-		public int? LineNumber { get; }
+		RootMessage = message.ToUpper();
+		LineNumber = line;
 	}
+
+	public SyntaxException(SyntaxException ex, int? line = null)
+		: base(string.Concat(ex.Message, (line.HasValue ? $" IN LINE {line}" : string.Empty)))
+	{
+		RootMessage = ex.RootMessage.ToUpper();
+		LineNumber = line;
+	}
+
+	public string RootMessage { get; }
+	public int? LineNumber { get; }
 }

--- a/src/ECMABasic.Core/Exceptions/UnexpectedCharacterException.cs
+++ b/src/ECMABasic.Core/Exceptions/UnexpectedCharacterException.cs
@@ -1,26 +1,25 @@
 ﻿using System;
 
-namespace ECMABasic.Core.Exceptions
+namespace ECMABasic.Core.Exceptions;
+
+public class UnexpectedCharacterException : Exception
 {
-    public class UnexpectedCharacterException : Exception
+    public UnexpectedCharacterException(int line, int column, string expected, string found)
+        : base($"({line}:{column}) Expected '{expected}', found '{found}'.")
     {
-        public UnexpectedCharacterException(int line, int column, string expected, string found)
-            : base($"({line}:{column}) Expected '{expected}', found '{found}'.")
-        {
-            Line = line;
-            Column = column;
-            Expected = expected;
-            Found = found;
-        }
-
-        public UnexpectedCharacterException(int line, int column, string expected, char found)
-            : this(line, column, expected, found.ToString())
-        {
-        }
-
-        public int Line { get; }
-        public int Column { get; }
-        public string Expected { get; }
-        public string Found { get; }
+        Line = line;
+        Column = column;
+        Expected = expected;
+        Found = found;
     }
+
+    public UnexpectedCharacterException(int line, int column, string expected, char found)
+        : this(line, column, expected, found.ToString())
+    {
+    }
+
+    public int Line { get; }
+    public int Column { get; }
+    public string Expected { get; }
+    public string Found { get; }
 }

--- a/src/ECMABasic.Core/Exceptions/UnexpectedTokenException.cs
+++ b/src/ECMABasic.Core/Exceptions/UnexpectedTokenException.cs
@@ -1,17 +1,16 @@
 ﻿using System;
 
-namespace ECMABasic.Core.Exceptions
-{
-	public class UnexpectedTokenException : Exception
-	{
-		public UnexpectedTokenException(TokenType expected, Token? actual)
-			: base($"({actual?.Line ?? 0}:{actual?.Column ?? 0}) Expected '{expected}', found '{actual?.Text ?? "{null}"}'")
-		{
-			ExpectedType = expected;
-			ActualToken = actual!;
-		}
+namespace ECMABasic.Core.Exceptions;
 
-		public TokenType ExpectedType { get; }
-		public Token ActualToken { get; }
+public class UnexpectedTokenException : Exception
+{
+	public UnexpectedTokenException(TokenType expected, Token? actual)
+		: base($"({actual?.Line ?? 0}:{actual?.Column ?? 0}) Expected '{expected}', found '{actual?.Text ?? "{null}"}'")
+	{
+		ExpectedType = expected;
+		ActualToken = actual!;
 	}
+
+	public TokenType ExpectedType { get; }
+	public Token ActualToken { get; }
 }

--- a/src/ECMABasic.Core/ExpressionParser.cs
+++ b/src/ECMABasic.Core/ExpressionParser.cs
@@ -1,56 +1,55 @@
-﻿namespace ECMABasic.Core
+﻿namespace ECMABasic.Core;
+
+public abstract class ExpressionParser
 {
-	public abstract class ExpressionParser
+	protected readonly ComplexTokenReader _reader;
+	protected readonly int? _lineNumber;
+	protected readonly bool _throwOnError;
+
+	protected ExpressionParser(ComplexTokenReader reader, int? lineNumber, bool throwOnError)
 	{
-		protected readonly ComplexTokenReader _reader;
-		protected readonly int? _lineNumber;
-		protected readonly bool _throwOnError;
+		_reader = reader;
+		_lineNumber = lineNumber;
+		_throwOnError = throwOnError;
+	}
 
-		protected ExpressionParser(ComplexTokenReader reader, int? lineNumber, bool throwOnError)
+	public abstract IExpression? Parse();
+
+	protected Token? ParseBooleanOperator()
+	{
+		var symbol = _reader.Next(TokenType.Symbol, false, @"\=|\<|\>");
+		if (symbol == null)
 		{
-			_reader = reader;
-			_lineNumber = lineNumber;
-			_throwOnError = throwOnError;
+			return null;
 		}
 
-		public abstract IExpression? Parse();
-
-		protected Token? ParseBooleanOperator()
+		if (symbol.Text == "<")
 		{
-			var symbol = _reader.Next(TokenType.Symbol, false, @"\=|\<|\>");
-			if (symbol == null)
+			var nextBit = _reader.Next(TokenType.Symbol, false, @"\=|\>");
+			if (nextBit != null)
 			{
-				return null;
-			}
-
-			if (symbol.Text == "<")
-			{
-				var nextBit = _reader.Next(TokenType.Symbol, false, @"\=|\>");
-				if (nextBit != null)
+				if (nextBit.Text == ">")
 				{
-					if (nextBit.Text == ">")
-					{
-						symbol = new Token(TokenType.Symbol, new[] { symbol, nextBit });  // Finish out the inequality operator.
-					}
-					else if (nextBit.Text == "=")
-					{
-						symbol = new Token(TokenType.Symbol, new[] { symbol, nextBit });  // Finish out the >= operator.
-					}
+					symbol = new Token(TokenType.Symbol, new[] { symbol, nextBit });  // Finish out the inequality operator.
+				}
+				else if (nextBit.Text == "=")
+				{
+					symbol = new Token(TokenType.Symbol, new[] { symbol, nextBit });  // Finish out the >= operator.
 				}
 			}
-			else if (symbol.Text == ">")
-			{
-				var nextBit = _reader.Next(TokenType.Symbol, false, @"\=");
-				if (nextBit != null)
-				{
-					if (nextBit.Text == "=")
-					{
-						symbol = new Token(TokenType.Symbol, new[] { symbol, nextBit });  // Finish out the <= operator.
-					}
-				}
-			}
-
-			return symbol;
 		}
+		else if (symbol.Text == ">")
+		{
+			var nextBit = _reader.Next(TokenType.Symbol, false, @"\=");
+			if (nextBit != null)
+			{
+				if (nextBit.Text == "=")
+				{
+					symbol = new Token(TokenType.Symbol, new[] { symbol, nextBit });  // Finish out the <= operator.
+				}
+			}
+		}
+
+		return symbol;
 	}
 }

--- a/src/ECMABasic.Core/ExpressionType.cs
+++ b/src/ECMABasic.Core/ExpressionType.cs
@@ -1,8 +1,7 @@
-﻿namespace ECMABasic.Core
+﻿namespace ECMABasic.Core;
+
+public enum ExpressionType
 {
-	public enum ExpressionType
-	{
-		Number,
-		String
-	}
+	Number,
+	String
 }

--- a/src/ECMABasic.Core/Expressions/AdditionExpression.cs
+++ b/src/ECMABasic.Core/Expressions/AdditionExpression.cs
@@ -1,26 +1,25 @@
 ﻿using System;
 
-namespace ECMABasic.Core.Expressions
+namespace ECMABasic.Core.Expressions;
+
+public class AdditionExpression : BinaryExpression
 {
-	public class AdditionExpression : BinaryExpression
+	public AdditionExpression(IExpression left, IExpression right)
+		: base(left, right)
 	{
-		public AdditionExpression(IExpression left, IExpression right)
-			: base(left, right)
-		{
-		}
+	}
 
-		public override object Evaluate(IEnvironment env)
-		{
-			var left = Convert.ToDouble(Left.Evaluate(env));
-			var right = Convert.ToDouble(Right.Evaluate(env));
-			return left + right;
-		}
+	public override object Evaluate(IEnvironment env)
+	{
+		var left = Convert.ToDouble(Left.Evaluate(env));
+		var right = Convert.ToDouble(Right.Evaluate(env));
+		return left + right;
+	}
 
-		public override string ToListing()
-		{
-			var left = (Left is BinaryExpression) ? string.Concat("(", Left.ToListing(), ")") : Left.ToListing();
-			var right = (Right is BinaryExpression) ? string.Concat("(", Right.ToListing(), ")") : Right.ToListing();
-			return string.Concat(left, "+", right);
-		}
+	public override string ToListing()
+	{
+		var left = (Left is BinaryExpression) ? string.Concat("(", Left.ToListing(), ")") : Left.ToListing();
+		var right = (Right is BinaryExpression) ? string.Concat("(", Right.ToListing(), ")") : Right.ToListing();
+		return string.Concat(left, "+", right);
 	}
 }

--- a/src/ECMABasic.Core/Expressions/BinaryExpression.cs
+++ b/src/ECMABasic.Core/Expressions/BinaryExpression.cs
@@ -1,26 +1,25 @@
-﻿namespace ECMABasic.Core.Expressions
+﻿namespace ECMABasic.Core.Expressions;
+
+public abstract class BinaryExpression : IExpression
 {
-	public abstract class BinaryExpression : IExpression
+	protected BinaryExpression(IExpression left, IExpression right)
 	{
-		protected BinaryExpression(IExpression left, IExpression right)
+		Left = left;
+		Right = right;
+
+		if (Left.Type != Right.Type)
 		{
-			Left = left;
-			Right = right;
-
-			if (Left.Type != Right.Type)
-			{
-				throw ExceptionFactory.MixedStringsAndNumbers();
-			}
+			throw ExceptionFactory.MixedStringsAndNumbers();
 		}
-
-		public IExpression Left { get; }
-		public IExpression Right { get; }
-
-		public ExpressionType Type => Left.Type;
-		
-		public bool IsReducible => Left.IsReducible && Right.IsReducible;
-
-		public abstract object Evaluate(IEnvironment env);
-		public abstract string ToListing();
 	}
+
+	public IExpression Left { get; }
+	public IExpression Right { get; }
+
+	public ExpressionType Type => Left.Type;
+	
+	public bool IsReducible => Left.IsReducible && Right.IsReducible;
+
+	public abstract object Evaluate(IEnvironment env);
+	public abstract string ToListing();
 }

--- a/src/ECMABasic.Core/Expressions/BooleanExpression.cs
+++ b/src/ECMABasic.Core/Expressions/BooleanExpression.cs
@@ -1,10 +1,9 @@
-﻿namespace ECMABasic.Core.Expressions
+﻿namespace ECMABasic.Core.Expressions;
+
+public abstract class BooleanExpression : BinaryExpression
 {
-	public abstract class BooleanExpression : BinaryExpression
+	protected BooleanExpression(IExpression left, IExpression right)
+		: base(left, right)
 	{
-		protected BooleanExpression(IExpression left, IExpression right)
-			: base(left, right)
-		{
-		}
 	}
 }

--- a/src/ECMABasic.Core/Expressions/CommaExpression.cs
+++ b/src/ECMABasic.Core/Expressions/CommaExpression.cs
@@ -1,36 +1,35 @@
 ﻿using ECMABasic.Core.Configuration;
 
-namespace ECMABasic.Core.Expressions
+namespace ECMABasic.Core.Expressions;
+
+/// <summary>
+/// Used when a comma occurs in a print list.
+/// </summary>
+public class CommaExpression : IPrintItemSeparator
 {
-	/// <summary>
-	/// Used when a comma occurs in a print list.
-	/// </summary>
-	public class CommaExpression : IPrintItemSeparator
+	private readonly IBasicConfiguration _config;
+
+	public CommaExpression(IBasicConfiguration? config = null)
 	{
-		private readonly IBasicConfiguration _config;
+		_config = config ?? MinimalBasicConfiguration.Instance;
+	}
 
-		public CommaExpression(IBasicConfiguration? config = null)
+	public object Evaluate(IEnvironment env)
+	{
+		var column = env.TerminalColumn / _config.TerminalColumnWidth;
+		var nextColumn = column + 1;
+		if (nextColumn >= _config.NumTerminalColumns)
 		{
-			_config = config ?? MinimalBasicConfiguration.Instance;
+			return "\n";
 		}
+		var nextColumnStart = nextColumn * _config.TerminalColumnWidth;
+		var numRemainingSpaces = nextColumnStart - env.TerminalColumn;
+		var text = new string(' ', numRemainingSpaces);
+		return text;
+	}
 
-		public object Evaluate(IEnvironment env)
-		{
-			var column = env.TerminalColumn / _config.TerminalColumnWidth;
-			var nextColumn = column + 1;
-			if (nextColumn >= _config.NumTerminalColumns)
-			{
-				return "\n";
-			}
-			var nextColumnStart = nextColumn * _config.TerminalColumnWidth;
-			var numRemainingSpaces = nextColumnStart - env.TerminalColumn;
-			var text = new string(' ', numRemainingSpaces);
-			return text;
-		}
-
-		public string ToListing()
-		{
-			return ",";
-		}
+	public string ToListing()
+	{
+		return ",";
 	}
 }

--- a/src/ECMABasic.Core/Expressions/DivisionExpression.cs
+++ b/src/ECMABasic.Core/Expressions/DivisionExpression.cs
@@ -1,41 +1,40 @@
 ﻿using System;
 
-namespace ECMABasic.Core.Expressions
+namespace ECMABasic.Core.Expressions;
+
+public class DivisionExpression : BinaryExpression
 {
-	public class DivisionExpression : BinaryExpression
+	public DivisionExpression(IExpression left, IExpression right)
+		: base(left, right)
 	{
-		public DivisionExpression(IExpression left, IExpression right)
-			: base(left, right)
-		{
-		}
+	}
 
-		public override object Evaluate(IEnvironment env)
+	public override object Evaluate(IEnvironment env)
+	{
+		var left = Convert.ToDouble(Left.Evaluate(env));
+		var right = Convert.ToDouble(Right.Evaluate(env));
+		if (right == 0)
 		{
-			var left = Convert.ToDouble(Left.Evaluate(env));
-			var right = Convert.ToDouble(Right.Evaluate(env));
-			if (right == 0)
+			if (left < 0)
 			{
-				if (left < 0)
-				{
-					return double.NegativeInfinity;
-				}
-				else if (left == 0)
-				{
-					return double.NaN;
-				}
-				else
-				{
-					return double.PositiveInfinity;
-				}
+				return double.NegativeInfinity;
 			}
-			return left / right;
+			else if (left == 0)
+			{
+				return double.NaN;
+			}
+			else
+			{
+				return double.PositiveInfinity;
+			}
 		}
+		return left / right;
+	}
 
-		public override string ToListing()
-		{
-			var left = (Left is BinaryExpression) ? string.Concat("(", Left.ToListing(), ")") : Left.ToListing();
-			var right = (Right is BinaryExpression) ? string.Concat("(", Right.ToListing(), ")") : Right.ToListing();
-			return string.Concat(left, "/", right);
-		}
+	public override string ToListing()
+	{
+		var left = (Left is BinaryExpression) ? string.Concat("(", Left.ToListing(), ")") : Left.ToListing();
+		var right = (Right is BinaryExpression) ? string.Concat("(", Right.ToListing(), ")") : Right.ToListing();
+		return string.Concat(left, "/", right);
 	}
 }

--- a/src/ECMABasic.Core/Expressions/EqualsExpression.cs
+++ b/src/ECMABasic.Core/Expressions/EqualsExpression.cs
@@ -1,24 +1,23 @@
-﻿namespace ECMABasic.Core.Expressions
+﻿namespace ECMABasic.Core.Expressions;
+
+public class EqualsExpression : BooleanExpression
 {
-	public class EqualsExpression : BooleanExpression
+	public EqualsExpression(IExpression left, IExpression right)
+		: base(left, right)
 	{
-		public EqualsExpression(IExpression left, IExpression right)
-			: base(left, right)
-		{
-		}
+	}
 
-		public override object Evaluate(IEnvironment env)
-		{
-			var left = Left.Evaluate(env);
-			var right = Right.Evaluate(env);
-			return left.Equals(right);
-		}
+	public override object Evaluate(IEnvironment env)
+	{
+		var left = Left.Evaluate(env);
+		var right = Right.Evaluate(env);
+		return left.Equals(right);
+	}
 
-		public override string ToListing()
-		{
-			var left = (Left is BinaryExpression) ? string.Concat("(", Left.ToListing(), ")") : Left.ToListing();
-			var right = (Right is BinaryExpression) ? string.Concat("(", Right.ToListing(), ")") : Right.ToListing();
-			return string.Concat(left, "=", right);
-		}
+	public override string ToListing()
+	{
+		var left = (Left is BinaryExpression) ? string.Concat("(", Left.ToListing(), ")") : Left.ToListing();
+		var right = (Right is BinaryExpression) ? string.Concat("(", Right.ToListing(), ")") : Right.ToListing();
+		return string.Concat(left, "=", right);
 	}
 }

--- a/src/ECMABasic.Core/Expressions/GreaterThanExpression.cs
+++ b/src/ECMABasic.Core/Expressions/GreaterThanExpression.cs
@@ -1,26 +1,25 @@
 ﻿using System;
 
-namespace ECMABasic.Core.Expressions
+namespace ECMABasic.Core.Expressions;
+
+public class GreaterThanExpression : BooleanExpression
 {
-	public class GreaterThanExpression : BooleanExpression
+	public GreaterThanExpression(IExpression left, IExpression right)
+		: base(left, right)
 	{
-		public GreaterThanExpression(IExpression left, IExpression right)
-			: base(left, right)
-		{
-		}
+	}
 
-		public override object Evaluate(IEnvironment env)
-		{
-			var left = Left.Evaluate(env);
-			var right = Right.Evaluate(env);
-			return (left as IComparable)!.CompareTo(right) > 0;
-		}
+	public override object Evaluate(IEnvironment env)
+	{
+		var left = Left.Evaluate(env);
+		var right = Right.Evaluate(env);
+		return (left as IComparable)!.CompareTo(right) > 0;
+	}
 
-		public override string ToListing()
-		{
-			var left = (Left is BinaryExpression) ? string.Concat("(", Left.ToListing(), ")") : Left.ToListing();
-			var right = (Right is BinaryExpression) ? string.Concat("(", Right.ToListing(), ")") : Right.ToListing();
-			return string.Concat(left, ">", right);
-		}
+	public override string ToListing()
+	{
+		var left = (Left is BinaryExpression) ? string.Concat("(", Left.ToListing(), ")") : Left.ToListing();
+		var right = (Right is BinaryExpression) ? string.Concat("(", Right.ToListing(), ")") : Right.ToListing();
+		return string.Concat(left, ">", right);
 	}
 }

--- a/src/ECMABasic.Core/Expressions/GreaterThanOrEqualExpression.cs
+++ b/src/ECMABasic.Core/Expressions/GreaterThanOrEqualExpression.cs
@@ -1,26 +1,25 @@
 ﻿using System;
 
-namespace ECMABasic.Core.Expressions
+namespace ECMABasic.Core.Expressions;
+
+public class GreaterThanOrEqualExpression : BooleanExpression
 {
-	public class GreaterThanOrEqualExpression : BooleanExpression
+	public GreaterThanOrEqualExpression(IExpression left, IExpression right)
+		: base(left, right)
 	{
-		public GreaterThanOrEqualExpression(IExpression left, IExpression right)
-			: base(left, right)
-		{
-		}
+	}
 
-		public override object Evaluate(IEnvironment env)
-		{
-			var left = Left.Evaluate(env);
-			var right = Right.Evaluate(env);
-			return (left as IComparable)!.CompareTo(right) >= 0;
-		}
+	public override object Evaluate(IEnvironment env)
+	{
+		var left = Left.Evaluate(env);
+		var right = Right.Evaluate(env);
+		return (left as IComparable)!.CompareTo(right) >= 0;
+	}
 
-		public override string ToListing()
-		{
-			var left = (Left is BinaryExpression) ? string.Concat("(", Left.ToListing(), ")") : Left.ToListing();
-			var right = (Right is BinaryExpression) ? string.Concat("(", Right.ToListing(), ")") : Right.ToListing();
-			return string.Concat(left, ">=", right);
-		}
+	public override string ToListing()
+	{
+		var left = (Left is BinaryExpression) ? string.Concat("(", Left.ToListing(), ")") : Left.ToListing();
+		var right = (Right is BinaryExpression) ? string.Concat("(", Right.ToListing(), ")") : Right.ToListing();
+		return string.Concat(left, ">=", right);
 	}
 }

--- a/src/ECMABasic.Core/Expressions/IntegerExpression.cs
+++ b/src/ECMABasic.Core/Expressions/IntegerExpression.cs
@@ -1,26 +1,25 @@
-﻿namespace ECMABasic.Core.Expressions
+﻿namespace ECMABasic.Core.Expressions;
+
+public class IntegerExpression : IExpression
 {
-	public class IntegerExpression : IExpression
+	public IntegerExpression(int value)
 	{
-		public IntegerExpression(int value)
-		{
-			Value = value;
-		}
+		Value = value;
+	}
 
-		public int Value { get; }
+	public int Value { get; }
 
-		public ExpressionType Type => ExpressionType.Number;
+	public ExpressionType Type => ExpressionType.Number;
 
-		public bool IsReducible => true;
+	public bool IsReducible => true;
 
-		public object Evaluate(IEnvironment env)
-		{
-			return Value;
-		}
+	public object Evaluate(IEnvironment env)
+	{
+		return Value;
+	}
 
-		public string ToListing()
-		{
-			return Value.ToString();
-		}
+	public string ToListing()
+	{
+		return Value.ToString();
 	}
 }

--- a/src/ECMABasic.Core/Expressions/InvolutionExpression.cs
+++ b/src/ECMABasic.Core/Expressions/InvolutionExpression.cs
@@ -1,29 +1,28 @@
 ﻿using System;
 
-namespace ECMABasic.Core.Expressions
+namespace ECMABasic.Core.Expressions;
+
+/// <summary>
+/// Involution = a number to a power.
+/// </summary>
+public class InvolutionExpression : BinaryExpression
 {
-	/// <summary>
-	/// Involution = a number to a power.
-	/// </summary>
-	public class InvolutionExpression : BinaryExpression
+	public InvolutionExpression(IExpression left, IExpression right)
+		: base(left, right)
 	{
-		public InvolutionExpression(IExpression left, IExpression right)
-			: base(left, right)
-		{
-		}
+	}
 
-		public override object Evaluate(IEnvironment env)
-		{
-			var left = Convert.ToDouble(Left.Evaluate(env));
-			var right = Convert.ToDouble(Right.Evaluate(env));
-			return Math.Pow(left, right);
-		}
+	public override object Evaluate(IEnvironment env)
+	{
+		var left = Convert.ToDouble(Left.Evaluate(env));
+		var right = Convert.ToDouble(Right.Evaluate(env));
+		return Math.Pow(left, right);
+	}
 
-		public override string ToListing()
-		{
-			var left = (Left is BinaryExpression) ? string.Concat("(", Left.ToListing(), ")") : Left.ToListing();
-			var right = (Right is BinaryExpression) ? string.Concat("(", Right.ToListing(), ")") : Right.ToListing();
-			return string.Concat(left, "^", right);
-		}
+	public override string ToListing()
+	{
+		var left = (Left is BinaryExpression) ? string.Concat("(", Left.ToListing(), ")") : Left.ToListing();
+		var right = (Right is BinaryExpression) ? string.Concat("(", Right.ToListing(), ")") : Right.ToListing();
+		return string.Concat(left, "^", right);
 	}
 }

--- a/src/ECMABasic.Core/Expressions/LessThanExpression.cs
+++ b/src/ECMABasic.Core/Expressions/LessThanExpression.cs
@@ -1,26 +1,25 @@
 ﻿using System;
 
-namespace ECMABasic.Core.Expressions
+namespace ECMABasic.Core.Expressions;
+
+public class LessThanExpression : BooleanExpression
 {
-	public class LessThanExpression : BooleanExpression
+	public LessThanExpression(IExpression left, IExpression right)
+		: base(left, right)
 	{
-		public LessThanExpression(IExpression left, IExpression right)
-			: base(left, right)
-		{
-		}
+	}
 
-		public override object Evaluate(IEnvironment env)
-		{
-			var left = Left.Evaluate(env);
-			var right = Right.Evaluate(env);
-			return (left as IComparable)!.CompareTo(right) < 0;
-		}
+	public override object Evaluate(IEnvironment env)
+	{
+		var left = Left.Evaluate(env);
+		var right = Right.Evaluate(env);
+		return (left as IComparable)!.CompareTo(right) < 0;
+	}
 
-		public override string ToListing()
-		{
-			var left = (Left is BinaryExpression) ? string.Concat("(", Left.ToListing(), ")") : Left.ToListing();
-			var right = (Right is BinaryExpression) ? string.Concat("(", Right.ToListing(), ")") : Right.ToListing();
-			return string.Concat(left, "<", right);
-		}
+	public override string ToListing()
+	{
+		var left = (Left is BinaryExpression) ? string.Concat("(", Left.ToListing(), ")") : Left.ToListing();
+		var right = (Right is BinaryExpression) ? string.Concat("(", Right.ToListing(), ")") : Right.ToListing();
+		return string.Concat(left, "<", right);
 	}
 }

--- a/src/ECMABasic.Core/Expressions/LessThanOrEqualExpression.cs
+++ b/src/ECMABasic.Core/Expressions/LessThanOrEqualExpression.cs
@@ -1,26 +1,25 @@
 ﻿using System;
 
-namespace ECMABasic.Core.Expressions
+namespace ECMABasic.Core.Expressions;
+
+public class LessThanOrEqualExpression : BooleanExpression
 {
-	public class LessThanOrEqualExpression : BooleanExpression
+	public LessThanOrEqualExpression(IExpression left, IExpression right)
+		: base(left, right)
 	{
-		public LessThanOrEqualExpression(IExpression left, IExpression right)
-			: base(left, right)
-		{
-		}
+	}
 
-		public override object Evaluate(IEnvironment env)
-		{
-			var left = Left.Evaluate(env);
-			var right = Right.Evaluate(env);
-			return (left as IComparable)!.CompareTo(right) <= 0;
-		}
+	public override object Evaluate(IEnvironment env)
+	{
+		var left = Left.Evaluate(env);
+		var right = Right.Evaluate(env);
+		return (left as IComparable)!.CompareTo(right) <= 0;
+	}
 
-		public override string ToListing()
-		{
-			var left = (Left is BinaryExpression) ? string.Concat("(", Left.ToListing(), ")") : Left.ToListing();
-			var right = (Right is BinaryExpression) ? string.Concat("(", Right.ToListing(), ")") : Right.ToListing();
-			return string.Concat(left, "<=", right);
-		}
+	public override string ToListing()
+	{
+		var left = (Left is BinaryExpression) ? string.Concat("(", Left.ToListing(), ")") : Left.ToListing();
+		var right = (Right is BinaryExpression) ? string.Concat("(", Right.ToListing(), ")") : Right.ToListing();
+		return string.Concat(left, "<=", right);
 	}
 }

--- a/src/ECMABasic.Core/Expressions/MultiplicationExpression.cs
+++ b/src/ECMABasic.Core/Expressions/MultiplicationExpression.cs
@@ -1,26 +1,25 @@
 ﻿using System;
 
-namespace ECMABasic.Core.Expressions
+namespace ECMABasic.Core.Expressions;
+
+public class MultiplicationExpression : BinaryExpression
 {
-	public class MultiplicationExpression : BinaryExpression
+	public MultiplicationExpression(IExpression left, IExpression right)
+		: base(left, right)
 	{
-		public MultiplicationExpression(IExpression left, IExpression right)
-			: base(left, right)
-		{
-		}
+	}
 
-		public override object Evaluate(IEnvironment env)
-		{
-			var left = Convert.ToDouble(Left.Evaluate(env));
-			var right = Convert.ToDouble(Right.Evaluate(env));
-			return left * right;
-		}
+	public override object Evaluate(IEnvironment env)
+	{
+		var left = Convert.ToDouble(Left.Evaluate(env));
+		var right = Convert.ToDouble(Right.Evaluate(env));
+		return left * right;
+	}
 
-		public override string ToListing()
-		{
-			var left = (Left is BinaryExpression) ? string.Concat("(", Left.ToListing(), ")") : Left.ToListing();
-			var right = (Right is BinaryExpression) ? string.Concat("(", Right.ToListing(), ")") : Right.ToListing();
-			return string.Concat(left, "*", right);
-		}
+	public override string ToListing()
+	{
+		var left = (Left is BinaryExpression) ? string.Concat("(", Left.ToListing(), ")") : Left.ToListing();
+		var right = (Right is BinaryExpression) ? string.Concat("(", Right.ToListing(), ")") : Right.ToListing();
+		return string.Concat(left, "*", right);
 	}
 }

--- a/src/ECMABasic.Core/Expressions/NegationExpression.cs
+++ b/src/ECMABasic.Core/Expressions/NegationExpression.cs
@@ -1,35 +1,34 @@
 ﻿using ECMABasic.Core.Exceptions;
 using System;
 
-namespace ECMABasic.Core.Expressions
+namespace ECMABasic.Core.Expressions;
+
+public class NegationExpression : IExpression
 {
-	public class NegationExpression : IExpression
+	public NegationExpression(IExpression root)
 	{
-		public NegationExpression(IExpression root)
+		if (root.Type != ExpressionType.Number)
 		{
-			if (root.Type != ExpressionType.Number)
-			{
-				throw ExceptionFactory.ExpectedNumericExpression();
-			}
-			Root = root;
+			throw ExceptionFactory.ExpectedNumericExpression();
 		}
+		Root = root;
+	}
 
-		public IExpression Root { get; }
+	public IExpression Root { get; }
 
-		public ExpressionType Type => ExpressionType.Number;
+	public ExpressionType Type => ExpressionType.Number;
 
-		public bool IsReducible => Root.IsReducible;
+	public bool IsReducible => Root.IsReducible;
 
-		public object Evaluate(IEnvironment env)
-		{
-			var root = Convert.ToDouble(Root.Evaluate(env));
-			return -root;
-		}
+	public object Evaluate(IEnvironment env)
+	{
+		var root = Convert.ToDouble(Root.Evaluate(env));
+		return -root;
+	}
 
-		public string ToListing()
-		{
-			var root = (Root is BinaryExpression) ? string.Concat("(", Root.ToListing(), ")") : Root.ToListing();
-			return string.Concat("-", root);
-		}
+	public string ToListing()
+	{
+		var root = (Root is BinaryExpression) ? string.Concat("(", Root.ToListing(), ")") : Root.ToListing();
+		return string.Concat("-", root);
 	}
 }

--- a/src/ECMABasic.Core/Expressions/NotEqualsExpression.cs
+++ b/src/ECMABasic.Core/Expressions/NotEqualsExpression.cs
@@ -1,24 +1,23 @@
-﻿namespace ECMABasic.Core.Expressions
+﻿namespace ECMABasic.Core.Expressions;
+
+public class NotEqualsExpression : BooleanExpression
 {
-	public class NotEqualsExpression : BooleanExpression
+	public NotEqualsExpression(IExpression left, IExpression right)
+		: base(left, right)
 	{
-		public NotEqualsExpression(IExpression left, IExpression right)
-			: base(left, right)
-		{
-		}
+	}
 
-		public override object Evaluate(IEnvironment env)
-		{
-			var left = Left.Evaluate(env);
-			var right = Right.Evaluate(env);
-			return !left.Equals(right);
-		}
+	public override object Evaluate(IEnvironment env)
+	{
+		var left = Left.Evaluate(env);
+		var right = Right.Evaluate(env);
+		return !left.Equals(right);
+	}
 
-		public override string ToListing()
-		{
-			var left = (Left is BinaryExpression) ? string.Concat("(", Left.ToListing(), ")") : Left.ToListing();
-			var right = (Right is BinaryExpression) ? string.Concat("(", Right.ToListing(), ")") : Right.ToListing();
-			return string.Concat(left, "<>", right);
-		}
+	public override string ToListing()
+	{
+		var left = (Left is BinaryExpression) ? string.Concat("(", Left.ToListing(), ")") : Left.ToListing();
+		var right = (Right is BinaryExpression) ? string.Concat("(", Right.ToListing(), ")") : Right.ToListing();
+		return string.Concat(left, "<>", right);
 	}
 }

--- a/src/ECMABasic.Core/Expressions/NumberExpression.cs
+++ b/src/ECMABasic.Core/Expressions/NumberExpression.cs
@@ -1,35 +1,34 @@
-﻿namespace ECMABasic.Core.Expressions
+﻿namespace ECMABasic.Core.Expressions;
+
+public class NumberExpression : IExpression
 {
-	public class NumberExpression : IExpression
+	public NumberExpression(double value)
 	{
-		public NumberExpression(double value)
-		{
-			Value = value;
-		}
+		Value = value;
+	}
 
-		public double Value { get; }
+	public double Value { get; }
 
-		public ExpressionType Type => ExpressionType.Number;
+	public ExpressionType Type => ExpressionType.Number;
 
-		public bool IsReducible => true;
+	public bool IsReducible => true;
 
-		/// <summary>
-		/// Get a new expression that negates this one.
-		/// </summary>
-		/// <returns>The new number expression.</returns>
-		public NumberExpression Negate()
-		{
-			return new NumberExpression(-Value);
-		}
+	/// <summary>
+	/// Get a new expression that negates this one.
+	/// </summary>
+	/// <returns>The new number expression.</returns>
+	public NumberExpression Negate()
+	{
+		return new NumberExpression(-Value);
+	}
 
-		public object Evaluate(IEnvironment env)
-		{
-			return Value;
-		}
+	public object Evaluate(IEnvironment env)
+	{
+		return Value;
+	}
 
-		public string ToListing()
-		{
-			return Value.ToString();
-		}
+	public string ToListing()
+	{
+		return Value.ToString();
 	}
 }

--- a/src/ECMABasic.Core/Expressions/SemicolonExpression.cs
+++ b/src/ECMABasic.Core/Expressions/SemicolonExpression.cs
@@ -1,19 +1,18 @@
-﻿namespace ECMABasic.Core.Expressions
-{
-	/// <summary>
-	/// Used when a semi-colon occurs in a print list.
-	/// </summary>
-	public class SemicolonExpression : IPrintItemSeparator
-	{
-		public object Evaluate(IEnvironment env)
-		{
-			// Nothing really to do here.  Printing will naturally move to the next column on it's own.
-			return string.Empty;
-		}
+﻿namespace ECMABasic.Core.Expressions;
 
-		public string ToListing()
-		{
-			return ";";
-		}
+/// <summary>
+/// Used when a semi-colon occurs in a print list.
+/// </summary>
+public class SemicolonExpression : IPrintItemSeparator
+{
+	public object Evaluate(IEnvironment env)
+	{
+		// Nothing really to do here.  Printing will naturally move to the next column on it's own.
+		return string.Empty;
+	}
+
+	public string ToListing()
+	{
+		return ";";
 	}
 }

--- a/src/ECMABasic.Core/Expressions/StringExpression.cs
+++ b/src/ECMABasic.Core/Expressions/StringExpression.cs
@@ -1,27 +1,26 @@
-﻿namespace ECMABasic.Core.Expressions
+﻿namespace ECMABasic.Core.Expressions;
+
+internal class StringExpression : IExpression
 {
-	internal class StringExpression : IExpression
+	public StringExpression(string text)
+		: base()
 	{
-		public StringExpression(string text)
-			: base()
-		{
-			Text = text;
-		}
+		Text = text;
+	}
 
-		public string Text { get; }
+	public string Text { get; }
 
-		public ExpressionType Type => ExpressionType.String;
+	public ExpressionType Type => ExpressionType.String;
 
-		public bool IsReducible => true;
+	public bool IsReducible => true;
 
-		public object Evaluate(IEnvironment env)
-		{
-			return Text;
-		}
+	public object Evaluate(IEnvironment env)
+	{
+		return Text;
+	}
 
-		public string ToListing()
-		{
-			return string.Concat("\"", Text, "\"");
-		}
+	public string ToListing()
+	{
+		return string.Concat("\"", Text, "\"");
 	}
 }

--- a/src/ECMABasic.Core/Expressions/SubtractionExpression.cs
+++ b/src/ECMABasic.Core/Expressions/SubtractionExpression.cs
@@ -1,26 +1,25 @@
 ﻿using System;
 
-namespace ECMABasic.Core.Expressions
+namespace ECMABasic.Core.Expressions;
+
+public class SubtractionExpression : BinaryExpression
 {
-	public class SubtractionExpression : BinaryExpression
+	public SubtractionExpression(IExpression left, IExpression right)
+		: base(left, right)
 	{
-		public SubtractionExpression(IExpression left, IExpression right)
-			: base(left, right)
-		{
-		}
+	}
 
-		public override object Evaluate(IEnvironment env)
-		{
-			var left = Convert.ToDouble(Left.Evaluate(env));
-			var right = Convert.ToDouble(Right.Evaluate(env));
-			return left - right;
-		}
+	public override object Evaluate(IEnvironment env)
+	{
+		var left = Convert.ToDouble(Left.Evaluate(env));
+		var right = Convert.ToDouble(Right.Evaluate(env));
+		return left - right;
+	}
 
-		public override string ToListing()
-		{
-			var left = (Left is BinaryExpression) ? string.Concat("(", Left.ToListing(), ")") : Left.ToListing();
-			var right = (Right is BinaryExpression) ? string.Concat("(", Right.ToListing(), ")") : Right.ToListing();
-			return string.Concat(left, "-", right);
-		}
+	public override string ToListing()
+	{
+		var left = (Left is BinaryExpression) ? string.Concat("(", Left.ToListing(), ")") : Left.ToListing();
+		var right = (Right is BinaryExpression) ? string.Concat("(", Right.ToListing(), ")") : Right.ToListing();
+		return string.Concat(left, "-", right);
 	}
 }

--- a/src/ECMABasic.Core/Expressions/TabExpression.cs
+++ b/src/ECMABasic.Core/Expressions/TabExpression.cs
@@ -3,53 +3,52 @@ using ECMABasic.Core.Exceptions;
 using System;
 using System.Text;
 
-namespace ECMABasic.Core.Expressions
+namespace ECMABasic.Core.Expressions;
+
+public class TabExpression : IPrintItem
 {
-	public class TabExpression : IPrintItem
+	private readonly IBasicConfiguration _config;
+
+	public TabExpression(IExpression value, IBasicConfiguration? config = null)
 	{
-		private readonly IBasicConfiguration _config;
+		Value = value;
+		_config = config ?? MinimalBasicConfiguration.Instance;
+	}
 
-		public TabExpression(IExpression value, IBasicConfiguration? config = null)
+	public IExpression Value { get; }
+
+	public object Evaluate(IEnvironment env)
+	{
+		var value = (int)Math.Round(Convert.ToDouble(Value.Evaluate(env)));
+		if (value < 1)
 		{
-			Value = value;
-			_config = config ?? MinimalBasicConfiguration.Instance;
+			value = 1;
+
+			// Report a non-fatal error, then continue execution.
+			env.ReportError(new RuntimeException("TAB OUT OF RANGE", env.CurrentLineNumber).Message);
 		}
 
-		public IExpression Value { get; }
-
-		public object Evaluate(IEnvironment env)
+		if (value > _config.TerminalWidth)
 		{
-			var value = (int)Math.Round(Convert.ToDouble(Value.Evaluate(env)));
-			if (value < 1)
-			{
-				value = 1;
-
-				// Report a non-fatal error, then continue execution.
-				env.ReportError(new RuntimeException("TAB OUT OF RANGE", env.CurrentLineNumber).Message);
-			}
-
-			if (value > _config.TerminalWidth)
-			{
-				value -= _config.TerminalWidth * (int)((value - 1) / _config.TerminalWidth);
-			}
-
-			var sb = new StringBuilder();
-			if (value < env.TerminalColumn)
-			{
-				sb.AppendLine();
-				sb.Append(new string(' ', value));
-			}
-			else
-			{
-				var numSpaceNeeded = value - env.TerminalColumn - 1;
-				sb.Append(new string(' ', numSpaceNeeded));
-			}
-			return sb.ToString();
+			value -= _config.TerminalWidth * (int)((value - 1) / _config.TerminalWidth);
 		}
 
-		public string ToListing()
+		var sb = new StringBuilder();
+		if (value < env.TerminalColumn)
 		{
-			return string.Concat("TAB(", Value.ToListing(), ")");
+			sb.AppendLine();
+			sb.Append(new string(' ', value));
 		}
+		else
+		{
+			var numSpaceNeeded = value - env.TerminalColumn - 1;
+			sb.Append(new string(' ', numSpaceNeeded));
+		}
+		return sb.ToString();
+	}
+
+	public string ToListing()
+	{
+		return string.Concat("TAB(", Value.ToListing(), ")");
 	}
 }

--- a/src/ECMABasic.Core/Expressions/VariableExpression.cs
+++ b/src/ECMABasic.Core/Expressions/VariableExpression.cs
@@ -1,64 +1,63 @@
 ﻿using System;
 
-namespace ECMABasic.Core.Expressions
+namespace ECMABasic.Core.Expressions;
+
+public class VariableExpression : IExpression
 {
-	public class VariableExpression : IExpression
+	public VariableExpression(string name)
 	{
-		public VariableExpression(string name)
+		Name = name;
+	}
+
+	public string Name { get; }
+
+	public bool IsString
+	{
+		get
 		{
-			Name = name;
+			return Name.EndsWith('$');
 		}
+	}
 
-		public string Name { get; }
-
-		public bool IsString
+	public bool IsNumeric
+	{
+		get
 		{
-			get
-			{
-				return Name.EndsWith('$');
-			}
+			return !IsString;
 		}
+	}
 
-		public bool IsNumeric
+	public ExpressionType Type
+	{
+		get
 		{
-			get
+			if (IsNumeric)
 			{
-				return !IsString;
-			}
-		}
-
-		public ExpressionType Type
-		{
-			get
-			{
-				if (IsNumeric)
-				{
-					return ExpressionType.Number;
-				}
-				else
-				{
-					return ExpressionType.String;
-				}
-			}
-		}
-
-		public bool IsReducible => false;
-
-		public object Evaluate(IEnvironment env)
-		{
-			if (IsString)
-			{
-				return env.GetStringVariableValue(Name);
+				return ExpressionType.Number;
 			}
 			else
 			{
-				return env.GetNumericVariableValue(Name);
+				return ExpressionType.String;
 			}
 		}
+	}
 
-		public string ToListing()
+	public bool IsReducible => false;
+
+	public object Evaluate(IEnvironment env)
+	{
+		if (IsString)
 		{
-			return Name;
+			return env.GetStringVariableValue(Name);
 		}
+		else
+		{
+			return env.GetNumericVariableValue(Name);
+		}
+	}
+
+	public string ToListing()
+	{
+		return Name;
 	}
 }

--- a/src/ECMABasic.Core/ForStackContext.cs
+++ b/src/ECMABasic.Core/ForStackContext.cs
@@ -1,34 +1,33 @@
 ﻿using ECMABasic.Core.Expressions;
 
-namespace ECMABasic.Core
+namespace ECMABasic.Core;
+
+public class ForStackContext : ICallStackContext
 {
-	public class ForStackContext : ICallStackContext
+	public ForStackContext(VariableExpression loopVar, double to, double step, int returnToLineNumber)
 	{
-		public ForStackContext(VariableExpression loopVar, double to, double step, int returnToLineNumber)
+		if (!loopVar.IsNumeric)
 		{
-			if (!loopVar.IsNumeric)
-			{
-				throw ExceptionFactory.ExpectedNumericVariable();
-			}
-			LoopVar = loopVar;
-			To = to;
-			Step = step;
-			BlockStartLineNumber = returnToLineNumber;
-			BlockEndLineNumber = null;
+			throw ExceptionFactory.ExpectedNumericVariable();
 		}
-
-		public VariableExpression LoopVar { get; }
-		public double To { get; }
-		public double Step { get; }
-
-		/// <summary>
-		/// Return to this line number when the NEXT is hit.
-		/// </summary>
-		public int BlockStartLineNumber { get; }
-
-		/// <summary>
-		/// The line is one past the closing NEXT block, and isn't defined until NEXT is hit the first time.
-		/// </summary>
-		public int? BlockEndLineNumber { get; set; }
+		LoopVar = loopVar;
+		To = to;
+		Step = step;
+		BlockStartLineNumber = returnToLineNumber;
+		BlockEndLineNumber = null;
 	}
+
+	public VariableExpression LoopVar { get; }
+	public double To { get; }
+	public double Step { get; }
+
+	/// <summary>
+	/// Return to this line number when the NEXT is hit.
+	/// </summary>
+	public int BlockStartLineNumber { get; }
+
+	/// <summary>
+	/// The line is one past the closing NEXT block, and isn't defined until NEXT is hit the first time.
+	/// </summary>
+	public int? BlockEndLineNumber { get; set; }
 }

--- a/src/ECMABasic.Core/FunctionDefinition.cs
+++ b/src/ECMABasic.Core/FunctionDefinition.cs
@@ -2,67 +2,66 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace ECMABasic.Core
+namespace ECMABasic.Core;
+
+public class FunctionDefinition
 {
-	public class FunctionDefinition
+	private readonly List<ExpressionType> _arguments;
+	private readonly Func<List<object>, object> _fn;
+
+	public FunctionDefinition(string name, IEnumerable<ExpressionType> args, Func<List<object>, object> fn)
 	{
-		private readonly List<ExpressionType> _arguments;
-		private readonly Func<List<object>, object> _fn;
+		Name = name;
+		_arguments = new List<ExpressionType>(args);
+		_fn = fn;
+	}
 
-		public FunctionDefinition(string name, IEnumerable<ExpressionType> args, Func<List<object>, object> fn)
+	public string Name { get; }
+
+	public ExpressionType Type
+	{
+		get
 		{
-			Name = name;
-			_arguments = new List<ExpressionType>(args);
-			_fn = fn;
-		}
-
-		public string Name { get; }
-
-		public ExpressionType Type
-		{
-			get
+			if (Name.EndsWith("$"))
 			{
-				if (Name.EndsWith("$"))
-				{
-					return ExpressionType.String;
-				}
-				else
-				{
-					return ExpressionType.Number;
-				}
+				return ExpressionType.String;
+			}
+			else
+			{
+				return ExpressionType.Number;
 			}
 		}
+	}
 
-		public bool CanInstantiate(IEnumerable<IExpression> args)
+	public bool CanInstantiate(IEnumerable<IExpression> args)
+	{
+		if (args.Count() != _arguments.Count)
 		{
-			if (args.Count() != _arguments.Count)
+			return false;
+		}
+		for (var n = 0; n < _arguments.Count; n++)
+		{
+			if (args.ElementAt(n).Type != _arguments[n])
 			{
 				return false;
 			}
-			for (var n = 0; n < _arguments.Count; n++)
-			{
-				if (args.ElementAt(n).Type != _arguments[n])
-				{
-					return false;
-				}
-			}
-			return true;
 		}
+		return true;
+	}
 
-		public FunctionExpression Instantiate(IEnumerable<IExpression> args, int? lineNumber = null)
+	public FunctionExpression Instantiate(IEnumerable<IExpression> args, int? lineNumber = null)
+	{
+		if (args.Count() != _arguments.Count)
 		{
-			if (args.Count() != _arguments.Count)
-			{
-				throw ExceptionFactory.ArgumentCountMismatch(lineNumber);
-			}
-			for (var n = 0; n < _arguments.Count; n++)
-			{
-				if (args.ElementAt(n).Type != _arguments[n])
-				{
-					throw ExceptionFactory.ArgumentTypeMismatch(lineNumber);
-				}
-			}
-			return new FunctionExpression(Name, _fn, args);
+			throw ExceptionFactory.ArgumentCountMismatch(lineNumber);
 		}
+		for (var n = 0; n < _arguments.Count; n++)
+		{
+			if (args.ElementAt(n).Type != _arguments[n])
+			{
+				throw ExceptionFactory.ArgumentTypeMismatch(lineNumber);
+			}
+		}
+		return new FunctionExpression(Name, _fn, args);
 	}
 }

--- a/src/ECMABasic.Core/FunctionExpression.cs
+++ b/src/ECMABasic.Core/FunctionExpression.cs
@@ -2,46 +2,45 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace ECMABasic.Core
+namespace ECMABasic.Core;
+
+public class FunctionExpression : IExpression
 {
-	public class FunctionExpression : IExpression
+	public FunctionExpression(string name, Func<List<object>, object> fn, IEnumerable<IExpression> args)
 	{
-		public FunctionExpression(string name, Func<List<object>, object> fn, IEnumerable<IExpression> args)
+		Name = name;
+
+		if (Name.EndsWith("$"))
 		{
-			Name = name;
-
-			if (Name.EndsWith("$"))
-			{
-				Type = ExpressionType.String;
-			}
-			else
-			{
-				Type = ExpressionType.Number;
-			}
-
-			Function = fn;
-
-			Arguments = new List<IExpression>(args);
+			Type = ExpressionType.String;
+		}
+		else
+		{
+			Type = ExpressionType.Number;
 		}
 
-		public string Name { get; }
+		Function = fn;
 
-		public Func<List<object>, object> Function { get; }
+		Arguments = new List<IExpression>(args);
+	}
 
-		public ExpressionType Type { get; }
+	public string Name { get; }
 
-		public List<IExpression> Arguments { get; }
+	public Func<List<object>, object> Function { get; }
 
-		public bool IsReducible => Arguments.All(x => x.IsReducible);
+	public ExpressionType Type { get; }
 
-		public object Evaluate(IEnvironment env)
-		{
-			return Function(Arguments.Select(x => x.Evaluate(env)).ToList());
-		}
+	public List<IExpression> Arguments { get; }
 
-		public string ToListing()
-		{
-			return string.Concat(Name, "(", string.Join(",", Arguments.Select(x => x.ToListing())), ")");
-		}
+	public bool IsReducible => Arguments.All(x => x.IsReducible);
+
+	public object Evaluate(IEnvironment env)
+	{
+		return Function(Arguments.Select(x => x.Evaluate(env)).ToList());
+	}
+
+	public string ToListing()
+	{
+		return string.Concat(Name, "(", string.Join(",", Arguments.Select(x => x.ToListing())), ")");
 	}
 }

--- a/src/ECMABasic.Core/FunctionFactory.cs
+++ b/src/ECMABasic.Core/FunctionFactory.cs
@@ -1,57 +1,56 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace ECMABasic.Core
+namespace ECMABasic.Core;
+
+// TODO: This really needs to be part of the environment rather than a global singleton.
+
+public class FunctionFactory
 {
-	// TODO: This really needs to be part of the environment rather than a global singleton.
+	private readonly List<FunctionDefinition> _functions = new();
 
-	public class FunctionFactory
+	static FunctionFactory()
 	{
-		private readonly List<FunctionDefinition> _functions = new();
+		Instance = new();
+	}
 
-		static FunctionFactory()
+	// TODO: Built-in functions: ATN, EXP, LOG, SQR
+	// DONE: Built-in functions: ABS, COS, INT, RND, SGN, SIN, TAN
+
+	// TODO: What are the rules for RND?  Is the 1 parameter inclusive or exclusive?  What is the lower bound?
+
+	private FunctionFactory()
+	{
+		Define("ABS", new[] { ExpressionType.Number }, args => Math.Abs(Convert.ToDouble(args[0])));
+		Define("COS", new[] { ExpressionType.Number }, args => Math.Cos(Convert.ToDouble(args[0])));
+		Define("INT", new[] { ExpressionType.Number }, args => Convert.ToInt32(args[0]));
+		Define("RND", new[] { ExpressionType.Number }, args => RandomFactory.Instance.Next(Convert.ToInt32(args[0])));
+		Define("SGN", new[] { ExpressionType.Number }, args => Math.Sign(Convert.ToDouble(args[0])));
+		Define("SIN", new[] { ExpressionType.Number }, args => Math.Sin(Convert.ToDouble(args[0])));
+		Define("TAN", new[] { ExpressionType.Number }, args => Math.Tan(Convert.ToDouble(args[0])));
+	}
+
+	public static FunctionFactory Instance { get; }
+
+	public void Define(string name, IEnumerable<ExpressionType> args, Func<List<object>, object> fn)
+	{
+		_functions.Add(new FunctionDefinition(name, args, fn));
+	}
+
+	/// <summary>
+	/// Get all functions with the given name.
+	/// </summary>
+	/// <param name="name">The function name to look for.</param>
+	/// <returns>A list of functions with the given name.</returns>
+	public IEnumerable<FunctionDefinition> Get(string name)
+	{
+		foreach (var fn in _functions)
 		{
-			Instance = new();
-		}
-
-		// TODO: Built-in functions: ATN, EXP, LOG, SQR
-		// DONE: Built-in functions: ABS, COS, INT, RND, SGN, SIN, TAN
-
-		// TODO: What are the rules for RND?  Is the 1 parameter inclusive or exclusive?  What is the lower bound?
-
-		private FunctionFactory()
-		{
-			Define("ABS", new[] { ExpressionType.Number }, args => Math.Abs(Convert.ToDouble(args[0])));
-			Define("COS", new[] { ExpressionType.Number }, args => Math.Cos(Convert.ToDouble(args[0])));
-			Define("INT", new[] { ExpressionType.Number }, args => Convert.ToInt32(args[0]));
-			Define("RND", new[] { ExpressionType.Number }, args => RandomFactory.Instance.Next(Convert.ToInt32(args[0])));
-			Define("SGN", new[] { ExpressionType.Number }, args => Math.Sign(Convert.ToDouble(args[0])));
-			Define("SIN", new[] { ExpressionType.Number }, args => Math.Sin(Convert.ToDouble(args[0])));
-			Define("TAN", new[] { ExpressionType.Number }, args => Math.Tan(Convert.ToDouble(args[0])));
-		}
-
-		public static FunctionFactory Instance { get; }
-
-		public void Define(string name, IEnumerable<ExpressionType> args, Func<List<object>, object> fn)
-		{
-			_functions.Add(new FunctionDefinition(name, args, fn));
-		}
-
-		/// <summary>
-		/// Get all functions with the given name.
-		/// </summary>
-		/// <param name="name">The function name to look for.</param>
-		/// <returns>A list of functions with the given name.</returns>
-		public IEnumerable<FunctionDefinition> Get(string name)
-		{
-			foreach (var fn in _functions)
+			if (fn.Name == name)
 			{
-				if (fn.Name == name)
-				{
-					yield return fn;
-				}
+				yield return fn;
 			}
-
 		}
+
 	}
 }

--- a/src/ECMABasic.Core/GosubStackContext.cs
+++ b/src/ECMABasic.Core/GosubStackContext.cs
@@ -1,15 +1,14 @@
-﻿namespace ECMABasic.Core
-{
-	public class GosubStackContext : ICallStackContext
-	{
-		public GosubStackContext(int lineNumber)
-		{
-			LineNumber = lineNumber;
-		}
+﻿namespace ECMABasic.Core;
 
-		/// <summary>
-		/// Return to this line number when the next RETURN is hit.
-		/// </summary>
-		public int LineNumber { get; }
+public class GosubStackContext : ICallStackContext
+{
+	public GosubStackContext(int lineNumber)
+	{
+		LineNumber = lineNumber;
 	}
+
+	/// <summary>
+	/// Return to this line number when the next RETURN is hit.
+	/// </summary>
+	public int LineNumber { get; }
 }

--- a/src/ECMABasic.Core/ICallStackContext.cs
+++ b/src/ECMABasic.Core/ICallStackContext.cs
@@ -1,6 +1,5 @@
-﻿namespace ECMABasic.Core
+﻿namespace ECMABasic.Core;
+
+public class ICallStackContext
 {
-	public class ICallStackContext
-	{
-	}
 }

--- a/src/ECMABasic.Core/IEnvironment.cs
+++ b/src/ECMABasic.Core/IEnvironment.cs
@@ -1,127 +1,126 @@
-﻿namespace ECMABasic.Core
+﻿namespace ECMABasic.Core;
+
+/// <summary>
+/// The environment that a program is run in.
+/// </summary>
+public interface IEnvironment : IErrorReporter
 {
 	/// <summary>
-	/// The environment that a program is run in.
+	/// The active interpreter.
 	/// </summary>
-	public interface IEnvironment : IErrorReporter
-	{
-		/// <summary>
-		/// The active interpreter.
-		/// </summary>
-		public Interpreter Interpreter { get; }
+	public Interpreter Interpreter { get; }
 
-		/// <summary>
-		/// The full program, ready to execute.
-		/// </summary>
-		public Program Program { get; }
+	/// <summary>
+	/// The full program, ready to execute.
+	/// </summary>
+	public Program Program { get; }
 
-		/// <summary>
-		/// The line number currently being executed.
-		/// If the program is not running this value will be null.
-		/// </summary>
-		public int CurrentLineNumber { get; set; }
+	/// <summary>
+	/// The line number currently being executed.
+	/// If the program is not running this value will be null.
+	/// </summary>
+	public int CurrentLineNumber { get; set; }
 
-		/// <summary>
-		/// The terminal row to write to next.
-		/// </summary>
-		public int TerminalRow { get; set; }
+	/// <summary>
+	/// The terminal row to write to next.
+	/// </summary>
+	public int TerminalRow { get; set; }
 
-		/// <summary>
-		/// The terminal column to write to next.
-		/// </summary>
-		public int TerminalColumn { get; set; }
+	/// <summary>
+	/// The terminal column to write to next.
+	/// </summary>
+	public int TerminalColumn { get; set; }
 
-		/// <summary>
-		/// Clear everything except for the screen.
-		/// </summary>
-		public void Clear();
+	/// <summary>
+	/// Clear everything except for the screen.
+	/// </summary>
+	public void Clear();
 
-		/// <summary>
-		/// Read a line from the input stream.
-		/// </summary>
-		/// <returns>The line that was read.</returns>
-		public string ReadLine();
+	/// <summary>
+	/// Read a line from the input stream.
+	/// </summary>
+	/// <returns>The line that was read.</returns>
+	public string ReadLine();
 
-		/// <summary>
-		/// Print a string to the output stream, followed by a new-line.
-		/// </summary>
-		/// <param name="text">The text to print.</param>
-		public void PrintLine(string text = "");
+	/// <summary>
+	/// Print a string to the output stream, followed by a new-line.
+	/// </summary>
+	/// <param name="text">The text to print.</param>
+	public void PrintLine(string text = "");
 
-		/// <summary>
-		/// Print a string to the output stream without a new-line.
-		/// </summary>
-		/// <param name="text">The text to print.</param>
-		public void Print(string text);
+	/// <summary>
+	/// Print a string to the output stream without a new-line.
+	/// </summary>
+	/// <param name="text">The text to print.</param>
+	public void Print(string text);
 
-		/// <summary>
-		/// Get the value of a variable.
-		/// </summary>
-		/// <param name="variableName">The variable to retrieve.</param>
-		/// <returns>The value of the variable.</returns>
-		public string GetStringVariableValue(string variableName);
+	/// <summary>
+	/// Get the value of a variable.
+	/// </summary>
+	/// <param name="variableName">The variable to retrieve.</param>
+	/// <returns>The value of the variable.</returns>
+	public string GetStringVariableValue(string variableName);
 
-		/// <summary>
-		/// Set the value of a variable.
-		/// </summary>
-		/// <param name="variableName">The name of the value.</param>
-		/// <param name="value">The value to assign.</param>
-		public void SetStringVariableValue(string variableName, string value);
+	/// <summary>
+	/// Set the value of a variable.
+	/// </summary>
+	/// <param name="variableName">The name of the value.</param>
+	/// <param name="value">The value to assign.</param>
+	public void SetStringVariableValue(string variableName, string value);
 
-		/// <summary>
-		/// Get the value of a variable.
-		/// </summary>
-		/// <param name="variableName">The variable to retrieve.</param>
-		/// <returns>The value of the variable.</returns>
-		public double GetNumericVariableValue(string variableName);
+	/// <summary>
+	/// Get the value of a variable.
+	/// </summary>
+	/// <param name="variableName">The variable to retrieve.</param>
+	/// <returns>The value of the variable.</returns>
+	public double GetNumericVariableValue(string variableName);
 
-		/// <summary>
-		/// Set the value of a variable.
-		/// </summary>
-		/// <param name="variableName">The name of the value.</param>
-		/// <param name="value">The value to assign.</param>
-		public void SetNumericVariableValue(string variableName, double value);
+	/// <summary>
+	/// Set the value of a variable.
+	/// </summary>
+	/// <param name="variableName">The name of the value.</param>
+	/// <param name="value">The value to assign.</param>
+	public void SetNumericVariableValue(string variableName, double value);
 
-		/// <summary>
-		/// Is the given line number defined?
-		/// </summary>
-		/// <param name="lineNumber">The line number to look for.</param>
-		/// <param name="throwsIfMissing">Should a runtime exception be thrown if the line number is not found?</param>
-		/// <returns>True or false; does the line number currently exist in the program?</returns>
-		public bool ValidateLineNumber(int lineNumber, bool throwsIfMissing = false);
+	/// <summary>
+	/// Is the given line number defined?
+	/// </summary>
+	/// <param name="lineNumber">The line number to look for.</param>
+	/// <param name="throwsIfMissing">Should a runtime exception be thrown if the line number is not found?</param>
+	/// <returns>True or false; does the line number currently exist in the program?</returns>
+	public bool ValidateLineNumber(int lineNumber, bool throwsIfMissing = false);
 
-		/// <summary>
-		/// Push a context onto the call stack for RETURN-ing from a GOSUB or resetting a loop.
-		/// </summary>
-		/// <param name="context">The context to use on the next iteration of whatever.</param>
-		public void PushCallStack(ICallStackContext context);
+	/// <summary>
+	/// Push a context onto the call stack for RETURN-ing from a GOSUB or resetting a loop.
+	/// </summary>
+	/// <param name="context">The context to use on the next iteration of whatever.</param>
+	public void PushCallStack(ICallStackContext context);
 
-		/// <summary>
-		/// Pop a context off of the call stack for RETURN-ing from a GOSUB or resetting a loop.
-		/// </summary>
-		/// <returns>The context we're currently working in.</returns>
-		public ICallStackContext? PopCallStack();
+	/// <summary>
+	/// Pop a context off of the call stack for RETURN-ing from a GOSUB or resetting a loop.
+	/// </summary>
+	/// <returns>The context we're currently working in.</returns>
+	public ICallStackContext? PopCallStack();
 
-		/// <summary>
-		/// Used by the Program evaluator to see if a stop has been requested.
-		/// </summary>
-		public void CheckForStopRequest();
+	/// <summary>
+	/// Used by the Program evaluator to see if a stop has been requested.
+	/// </summary>
+	public void CheckForStopRequest();
 
-		/// <summary>
-		/// Load and interpret a file.
-		/// </summary>
-		/// <param name="filename">The file to load.</param>
-		public bool LoadFile(string filename);
+	/// <summary>
+	/// Load and interpret a file.
+	/// </summary>
+	/// <param name="filename">The file to load.</param>
+	public bool LoadFile(string filename);
 
-		/// <summary>
-		/// Read the next datum and increment the index.
-		/// </summary>
-		/// <returns>The next piece of data.</returns>
-		public IExpression ReadData();
+	/// <summary>
+	/// Read the next datum and increment the index.
+	/// </summary>
+	/// <returns>The next piece of data.</returns>
+	public IExpression ReadData();
 
-		/// <summary>
-		/// Reset the data pointer to the first datum.
-		/// </summary>
-		public void ResetDataPointer();
-	}
+	/// <summary>
+	/// Reset the data pointer to the first datum.
+	/// </summary>
+	public void ResetDataPointer();
 }

--- a/src/ECMABasic.Core/IErrorReporter.cs
+++ b/src/ECMABasic.Core/IErrorReporter.cs
@@ -4,17 +4,16 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace ECMABasic.Core
+namespace ECMABasic.Core;
+
+/// <summary>
+/// Handles storing up errors from either interpreting, compiling, or runtime.
+/// </summary>
+public interface IErrorReporter
 {
 	/// <summary>
-	/// Handles storing up errors from either interpreting, compiling, or runtime.
+	/// Record an error for later viewing.
 	/// </summary>
-	public interface IErrorReporter
-	{
-		/// <summary>
-		/// Record an error for later viewing.
-		/// </summary>
-		/// <param name="message">The error message to record.</param>
-		public void ReportError(string message);
-	}
+	/// <param name="message">The error message to record.</param>
+	public void ReportError(string message);
 }

--- a/src/ECMABasic.Core/IExpression.cs
+++ b/src/ECMABasic.Core/IExpression.cs
@@ -1,15 +1,14 @@
-﻿namespace ECMABasic.Core
-{
-	public interface IExpression : IPrintItem
-	{
-		/// <summary>
-		/// Is it a number, or a string?
-		/// </summary>
-		public ExpressionType Type { get; }
+﻿namespace ECMABasic.Core;
 
-		/// <summary>
-		/// Can the expression tree be reduced to a literal?
-		/// </summary>
-		public bool IsReducible { get; }
-	}
+public interface IExpression : IPrintItem
+{
+	/// <summary>
+	/// Is it a number, or a string?
+	/// </summary>
+	public ExpressionType Type { get; }
+
+	/// <summary>
+	/// Can the expression tree be reduced to a literal?
+	/// </summary>
+	public bool IsReducible { get; }
 }

--- a/src/ECMABasic.Core/IListable.cs
+++ b/src/ECMABasic.Core/IListable.cs
@@ -1,11 +1,10 @@
-﻿namespace ECMABasic.Core
+﻿namespace ECMABasic.Core;
+
+public interface IListable
 {
-	public interface IListable
-	{
-        /// <summary>
-        /// Output a string formatted for the output of a LIST statement.
-        /// </summary>
-        /// <returns>The textual representation of this item.</returns>
-        public string ToListing();
-    }
+    /// <summary>
+    /// Output a string formatted for the output of a LIST statement.
+    /// </summary>
+    /// <returns>The textual representation of this item.</returns>
+    public string ToListing();
 }

--- a/src/ECMABasic.Core/IPrintItem.cs
+++ b/src/ECMABasic.Core/IPrintItem.cs
@@ -1,18 +1,17 @@
-﻿namespace ECMABasic.Core
+﻿namespace ECMABasic.Core;
+
+/// <summary>
+/// Represents a thing that can be sent to the PRINT statement.
+/// </summary>
+/// <remarks>
+/// A print-item may not be a valid expression component.  e.g. TAB.
+/// </remarks>
+public interface IPrintItem : IListable
 {
 	/// <summary>
-	/// Represents a thing that can be sent to the PRINT statement.
+	/// Convert the expression a base type.
 	/// </summary>
-	/// <remarks>
-	/// A print-item may not be a valid expression component.  e.g. TAB.
-	/// </remarks>
-	public interface IPrintItem : IListable
-	{
-		/// <summary>
-		/// Convert the expression a base type.
-		/// </summary>
-		/// <param name="env">The environment to evaluate against.</param>
-		/// <returns>The text representation of this expression.</returns>
-		public object Evaluate(IEnvironment env);
-	}
+	/// <param name="env">The environment to evaluate against.</param>
+	/// <returns>The text representation of this expression.</returns>
+	public object Evaluate(IEnvironment env);
 }

--- a/src/ECMABasic.Core/IPrintItemSeparator.cs
+++ b/src/ECMABasic.Core/IPrintItemSeparator.cs
@@ -1,6 +1,5 @@
-﻿namespace ECMABasic.Core
+﻿namespace ECMABasic.Core;
+
+public interface IPrintItemSeparator : IPrintItem
 {
-	public interface IPrintItemSeparator : IPrintItem
-	{
-	}
 }

--- a/src/ECMABasic.Core/IStatement.cs
+++ b/src/ECMABasic.Core/IStatement.cs
@@ -1,15 +1,14 @@
-﻿namespace ECMABasic.Core
+﻿namespace ECMABasic.Core;
+
+/// <summary>
+/// Represents a single executable statement.
+/// </summary>
+public interface IStatement : IListable
 {
     /// <summary>
-    /// Represents a single executable statement.
+    /// Execute this statement inside of an environment.
     /// </summary>
-    public interface IStatement : IListable
-    {
-        /// <summary>
-        /// Execute this statement inside of an environment.
-        /// </summary>
-        /// <param name="env">The environment to execute the statement inside of.</param>
-        /// <param name="isImmediate">Is the statement running in immediate-mode, or as part of a program?</param>
-        public abstract void Execute(IEnvironment env, bool isImmediate);
-    }
+    /// <param name="env">The environment to execute the statement inside of.</param>
+    /// <param name="isImmediate">Is the statement running in immediate-mode, or as part of a program?</param>
+    public abstract void Execute(IEnvironment env, bool isImmediate);
 }

--- a/src/ECMABasic.Core/Interpreter.cs
+++ b/src/ECMABasic.Core/Interpreter.cs
@@ -6,373 +6,372 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace ECMABasic.Core
+namespace ECMABasic.Core;
+
+// TODO: The end-goal is to have a single interpreter that you can plug feature sets into, like adding BASIC-1 on top of Minimal BASIC.
+
+/// <summary>
+/// Convert the source text into an abstract syntax tree.
+/// </summary>
+public class Interpreter
 {
-	// TODO: The end-goal is to have a single interpreter that you can plug feature sets into, like adding BASIC-1 on top of Minimal BASIC.
+	private readonly List<StatementParser> _lineStatements;
+
+	protected ComplexTokenReader _reader = null!;
+	private readonly IBasicConfiguration _config;
+
+	public Interpreter(IBasicConfiguration? config = null)
+	{
+		_config = config ?? MinimalBasicConfiguration.Instance;
+
+		_lineStatements = new List<StatementParser>()
+		{
+			new EndStatementParser(),
+			new LetStatementParser(),
+			new PrintStatementParser(),
+			new StopStatementParser(),
+			new RemarkStatementParser(),
+			new GotoStatementParser(),
+			new GosubStatementParser(),
+			new ReturnStatementParser(),
+			new IfThenStatementParser(),
+			new OnGotoStatementParser(),
+			new RestoreStatementParser(),
+			new ReadStatementParser(),
+			new DataStatementParser(),
+			new InputStatementParser(),
+			new NextStatementParser(),
+		};
+	}
 
 	/// <summary>
-	/// Convert the source text into an abstract syntax tree.
+	/// Create an interpreter that will interpret the input text directly.
 	/// </summary>
-	public class Interpreter
+	/// <param name="text">The text to interpret.</param>
+	/// <param name="env">The execution environment.</param>
+	/// <param name="config">Optional BASIC configuration settings.</param>
+	/// <returns>Was the input interpreted successfully?</returns>
+	public static bool FromText(string text, IEnvironment env, IBasicConfiguration? config = null)
 	{
-		private readonly List<StatementParser> _lineStatements;
+		var interpreter = new Interpreter(config);
+		return interpreter.InterpretProgramFromText(env, text);
+	}
 
-		protected ComplexTokenReader _reader = null!;
-		private readonly IBasicConfiguration _config;
+	/// <summary>
+	/// Create an interpreter that will interpret the source text contained at the file path.
+	/// </summary>
+	/// <param name="path">The path to the file to interpret.</param>
+	/// <param name="env">The execution environment.</param>
+	/// <param name="config">Optional BASIC configuration settings.</param>
+	/// <returns>Was the input interpreted successfully?</returns>
+	public static bool FromFile(string path, IEnvironment env, IBasicConfiguration? config = null)
+	{
+		var interpreter = new Interpreter(config);
+		return interpreter.InterpretProgramFromFile(env, path);
+	}
 
-		public Interpreter(IBasicConfiguration? config = null)
+	/// <summary>
+	/// Allow interpretation of additional statements.
+	/// </summary>
+	/// <param name="additionalStatements">The statements to add to the interpreter.</param>
+	public void InjectStatements(IEnumerable<StatementParser> additionalStatements)
+	{
+		_lineStatements.AddRange(additionalStatements);
+	}
+
+	/// <summary>
+	/// Interpret the source text contained at the file path.
+	/// </summary>
+	/// <param name="env">The execution environment.</param>
+	/// <param name="path">The path to the file to interpret.</param>
+	/// <returns>Was the input interpreted successfully?</returns>
+	public bool InterpretProgramFromFile(IEnvironment env, string path)
+	{
+		_reader = ComplexTokenReader.FromFile(path);
+		return InterpretProgram(env);
+	}
+
+	/// <summary>
+	/// Interpret the input text directly.
+	/// </summary>
+	/// <param name="env">The execution environment.</param>
+	/// <param name="text">The text to interpret.</param>
+	/// <returns>Was the input interpreted successfully?</returns>
+	public bool InterpretProgramFromText(IEnvironment env, string text)
+	{
+		_reader = ComplexTokenReader.FromText(text);
+		return InterpretProgram(env);
+	}
+
+	private bool InterpretProgram(IEnvironment env)
+	{
+		try
 		{
-			_config = config ?? MinimalBasicConfiguration.Instance;
-
-			_lineStatements = new List<StatementParser>()
-			{
-				new EndStatementParser(),
-				new LetStatementParser(),
-				new PrintStatementParser(),
-				new StopStatementParser(),
-				new RemarkStatementParser(),
-				new GotoStatementParser(),
-				new GosubStatementParser(),
-				new ReturnStatementParser(),
-				new IfThenStatementParser(),
-				new OnGotoStatementParser(),
-				new RestoreStatementParser(),
-				new ReadStatementParser(),
-				new DataStatementParser(),
-				new InputStatementParser(),
-				new NextStatementParser(),
-			};
-		}
-
-		/// <summary>
-		/// Create an interpreter that will interpret the input text directly.
-		/// </summary>
-		/// <param name="text">The text to interpret.</param>
-		/// <param name="env">The execution environment.</param>
-		/// <param name="config">Optional BASIC configuration settings.</param>
-		/// <returns>Was the input interpreted successfully?</returns>
-		public static bool FromText(string text, IEnvironment env, IBasicConfiguration? config = null)
-		{
-			var interpreter = new Interpreter(config);
-			return interpreter.InterpretProgramFromText(env, text);
-		}
-
-		/// <summary>
-		/// Create an interpreter that will interpret the source text contained at the file path.
-		/// </summary>
-		/// <param name="path">The path to the file to interpret.</param>
-		/// <param name="env">The execution environment.</param>
-		/// <param name="config">Optional BASIC configuration settings.</param>
-		/// <returns>Was the input interpreted successfully?</returns>
-		public static bool FromFile(string path, IEnvironment env, IBasicConfiguration? config = null)
-		{
-			var interpreter = new Interpreter(config);
-			return interpreter.InterpretProgramFromFile(env, path);
-		}
-
-		/// <summary>
-		/// Allow interpretation of additional statements.
-		/// </summary>
-		/// <param name="additionalStatements">The statements to add to the interpreter.</param>
-		public void InjectStatements(IEnumerable<StatementParser> additionalStatements)
-		{
-			_lineStatements.AddRange(additionalStatements);
-		}
-
-		/// <summary>
-		/// Interpret the source text contained at the file path.
-		/// </summary>
-		/// <param name="env">The execution environment.</param>
-		/// <param name="path">The path to the file to interpret.</param>
-		/// <returns>Was the input interpreted successfully?</returns>
-		public bool InterpretProgramFromFile(IEnvironment env, string path)
-		{
-			_reader = ComplexTokenReader.FromFile(path);
-			return InterpretProgram(env);
-		}
-
-		/// <summary>
-		/// Interpret the input text directly.
-		/// </summary>
-		/// <param name="env">The execution environment.</param>
-		/// <param name="text">The text to interpret.</param>
-		/// <returns>Was the input interpreted successfully?</returns>
-		public bool InterpretProgramFromText(IEnvironment env, string text)
-		{
-			_reader = ComplexTokenReader.FromText(text);
-			return InterpretProgram(env);
-		}
-
-		private bool InterpretProgram(IEnvironment env)
-		{
-			try
-			{
-				while (true)
-				{
-					if (!ProcessBlock(env, null!))
-					{
-						break;
-					}
-				}
-
-				var token = _reader.Next();
-				if (token != null)
-				{
-					throw new InvalidOperationException("EXPECTED END-OF-RECORD");
-				}
-				return true;
-			}
-			catch (SyntaxException e)
-			{
-				env.ReportError(e.Message);
-				return false;
-			}
-		}
-
-		/// <summary>
-		/// Process the next line or for-block.
-		/// </summary>
-		/// <returns></returns>
-		protected bool ProcessBlock(IEnvironment env, ProgramLine? parent)
-		{
-			return ProcessLine(env, parent) || ProcessForBlock(env, parent);
-		}
-
-		private bool ProcessLine(IEnvironment env, ProgramLine? parent)
-		{
-			var startIndex = _reader.TokenIndex;
-			if (_reader.IsAtEnd)
-			{
-				return false;
-			}
-
-			var lineNumber = ProcessLineNumber(false);
-			if (!lineNumber.HasValue)
-			{
-				_reader.Seek(startIndex);
-				return false;
-			}
-
-			if (ProcessSpace(false) == null)
-			{
-				// An empty line triggers a deletion.
-				env.Program.Insert(new ProgramLine(lineNumber.Value, null, null));
-				return true;
-			}
-
-			var statement = ProcessStatement(lineNumber, false);
-			if (statement == null)
-			{
-				_reader.Seek(startIndex);
-				return false;
-			}
-
-			// Optional space.
-			ProcessSpace(false);
-
-			// Require an end-of-line.
-			ProcessEndOfLine();
-
-			env.Program.Insert(new ProgramLine(lineNumber.Value, statement, parent));
-			return true;
-		}
-
-		/// <summary>
-		/// Read a line number off of the token stream.
-		/// An exception will occur if a line number could not be read.
-		/// </summary>
-		/// <returns>The line number.</returns>
-		private int? ProcessLineNumber(bool throwsOnError = true)
-		{
-			var lineNumber = _reader.NextInteger(_config.MaxLineNumberDigits, throwsOnError);
-			return lineNumber;
-		}
-
-		/// <summary>
-		/// Read the end-of-line token off of the token stream.
-		/// An exception will occur if the end-of-line could not be read.
-		/// </summary>
-		protected void ProcessEndOfLine()
-		{
-			var next = _reader.Next();
-			if (next == null)
-			{
-				return;
-			}
-			if (next.Type != TokenType.EndOfLine)
-			{
-				throw new UnexpectedTokenException(TokenType.EndOfLine, next);
-			}
-		}
-
-		/// <summary>
-		/// Read whitespace off of the token stream.
-		/// An exception will optionally occur if whitespace could not be found.
-		/// </summary>
-		/// <param name="throwOnError">Throw an exception if space is not found.  Default to true.</param>
-		/// <returns>The space token.</returns>
-		protected Token? ProcessSpace(bool throwOnError = true)
-		{
-			return _reader.Next(TokenType.Space, throwOnError);
-		}
-
-		protected IStatement? ProcessStatement(int? lineNumber, bool throwOnError = true)
-		{
-			foreach (var parser in _lineStatements)
-			{
-				var stmt = parser.Parse(_reader, lineNumber);
-				if (stmt != null)
-				{
-					if (stmt is NextStatement)
-					{
-						throw ExceptionFactory.NextWithoutFor(lineNumber);
-					}
-					return stmt;
-				}
-			}
-
-			if (throwOnError)
-			{
-				throw new SyntaxException("A STATEMENT WAS EXPECTED", lineNumber);
-			}
-			return null;
-		}
-
-		private void ValidateNotUsingPreviousControlVariable(ProgramLine forLine, ProgramLine? parent)
-		{
-			if (parent == null)
-			{
-				return;
-			}
-
-			if (parent.Statement is not ForStatement stmt)
-			{
-				return;
-			}
-
-			if (stmt.LoopVar.Name == (forLine.Statement as ForStatement)!.LoopVar.Name)
-			{
-				throw ExceptionFactory.ForUsingPreviousControlVariable(forLine.LineNumber);
-			}
-
-			if (parent.Parent == null)
-			{
-				return;
-			}
-
-			ValidateNotUsingPreviousControlVariable(forLine, parent.Parent);
-		}
-
-		private bool ProcessForBlock(IEnvironment env, ProgramLine? parent)
-		{
-			if (!ProcessForLine(env, parent))
-			{
-				return false;
-			}
-			var forLine = env.Program.Last();
-			ValidateNotUsingPreviousControlVariable(forLine, parent);
-
 			while (true)
 			{
-				if (ProcessNextLine(env, forLine))
-				{
-					break;
-				}
-				if (!ProcessBlock(env, forLine))
+				if (!ProcessBlock(env, null!))
 				{
 					break;
 				}
 			}
 
-			if (!(env.Program.Last().Statement is NextStatement))
+			var token = _reader.Next();
+			if (token != null)
 			{
-				throw ExceptionFactory.ForWithoutNext(forLine.LineNumber);
+				throw new InvalidOperationException("EXPECTED END-OF-RECORD");
 			}
-
 			return true;
 		}
-
-		protected bool ProcessForLine(IEnvironment env, ProgramLine? parent)
+		catch (SyntaxException e)
 		{
-			var startIndex = _reader.TokenIndex;
-			if (_reader.IsAtEnd)
-			{
-				return false;
-			}
-
-			var lineNumber = ProcessLineNumber(false);
-			if (!lineNumber.HasValue)
-			{
-				_reader.Seek(startIndex);
-				return false;
-			}
-
-			if (ProcessSpace(false) == null)
-			{
-				// An empty line triggers a deletion.
-				env.Program.Delete(lineNumber.Value);
-				return true;
-			}
-
-			var statement = new ForStatementParser().Parse(_reader, lineNumber);
-			if (statement == null)
-			{
-				_reader.Seek(startIndex);
-				return false;
-			}
-
-			// Optional space.
-			ProcessSpace(false);
-
-			// Require an end-of-line.
-			ProcessEndOfLine();
-
-			env.Program.Insert(new ProgramLine(lineNumber.Value, statement, parent));
-			return true;
+			env.ReportError(e.Message);
+			return false;
 		}
+	}
 
-		protected bool ProcessNextLine(IEnvironment env, ProgramLine? parent)
+	/// <summary>
+	/// Process the next line or for-block.
+	/// </summary>
+	/// <returns></returns>
+	protected bool ProcessBlock(IEnvironment env, ProgramLine? parent)
+	{
+		return ProcessLine(env, parent) || ProcessForBlock(env, parent);
+	}
+
+	private bool ProcessLine(IEnvironment env, ProgramLine? parent)
+	{
+		var startIndex = _reader.TokenIndex;
+		if (_reader.IsAtEnd)
 		{
-			var startIndex = _reader.TokenIndex;
-			if (_reader.IsAtEnd)
-			{
-				return false;
-			}
+			return false;
+		}
 
-			var lineNumber = ProcessLineNumber(false);
-			if (!lineNumber.HasValue)
-			{
-				_reader.Seek(startIndex);
-				return false;
-			}
+		var lineNumber = ProcessLineNumber(false);
+		if (!lineNumber.HasValue)
+		{
+			_reader.Seek(startIndex);
+			return false;
+		}
 
-			if (ProcessSpace(false) == null)
-			{
-				// An empty line triggers a deletion.
-				env.Program.Insert(new ProgramLine(lineNumber.Value, null, null));
-				return true;
-			}
-
-			var statement = new NextStatementParser().Parse(_reader, lineNumber);
-			if (statement == null)
-			{
-				_reader.Seek(startIndex);
-				return false;
-			}
-
-			if ((statement as NextStatement)!.LoopVar.Name != (parent!.Statement as ForStatement)!.LoopVar.Name)
-			{
-				throw ExceptionFactory.NextWithoutFor(lineNumber);
-			}
-
-			// Optional space.
-			ProcessSpace(false);
-
-			// Require an end-of-line.
-			ProcessEndOfLine();
-
-			env.Program.Insert(new ProgramLine(lineNumber.Value, statement, parent));
+		if (ProcessSpace(false) == null)
+		{
+			// An empty line triggers a deletion.
+			env.Program.Insert(new ProgramLine(lineNumber.Value, null, null));
 			return true;
 		}
+
+		var statement = ProcessStatement(lineNumber, false);
+		if (statement == null)
+		{
+			_reader.Seek(startIndex);
+			return false;
+		}
+
+		// Optional space.
+		ProcessSpace(false);
+
+		// Require an end-of-line.
+		ProcessEndOfLine();
+
+		env.Program.Insert(new ProgramLine(lineNumber.Value, statement, parent));
+		return true;
+	}
+
+	/// <summary>
+	/// Read a line number off of the token stream.
+	/// An exception will occur if a line number could not be read.
+	/// </summary>
+	/// <returns>The line number.</returns>
+	private int? ProcessLineNumber(bool throwsOnError = true)
+	{
+		var lineNumber = _reader.NextInteger(_config.MaxLineNumberDigits, throwsOnError);
+		return lineNumber;
+	}
+
+	/// <summary>
+	/// Read the end-of-line token off of the token stream.
+	/// An exception will occur if the end-of-line could not be read.
+	/// </summary>
+	protected void ProcessEndOfLine()
+	{
+		var next = _reader.Next();
+		if (next == null)
+		{
+			return;
+		}
+		if (next.Type != TokenType.EndOfLine)
+		{
+			throw new UnexpectedTokenException(TokenType.EndOfLine, next);
+		}
+	}
+
+	/// <summary>
+	/// Read whitespace off of the token stream.
+	/// An exception will optionally occur if whitespace could not be found.
+	/// </summary>
+	/// <param name="throwOnError">Throw an exception if space is not found.  Default to true.</param>
+	/// <returns>The space token.</returns>
+	protected Token? ProcessSpace(bool throwOnError = true)
+	{
+		return _reader.Next(TokenType.Space, throwOnError);
+	}
+
+	protected IStatement? ProcessStatement(int? lineNumber, bool throwOnError = true)
+	{
+		foreach (var parser in _lineStatements)
+		{
+			var stmt = parser.Parse(_reader, lineNumber);
+			if (stmt != null)
+			{
+				if (stmt is NextStatement)
+				{
+					throw ExceptionFactory.NextWithoutFor(lineNumber);
+				}
+				return stmt;
+			}
+		}
+
+		if (throwOnError)
+		{
+			throw new SyntaxException("A STATEMENT WAS EXPECTED", lineNumber);
+		}
+		return null;
+	}
+
+	private void ValidateNotUsingPreviousControlVariable(ProgramLine forLine, ProgramLine? parent)
+	{
+		if (parent == null)
+		{
+			return;
+		}
+
+		if (parent.Statement is not ForStatement stmt)
+		{
+			return;
+		}
+
+		if (stmt.LoopVar.Name == (forLine.Statement as ForStatement)!.LoopVar.Name)
+		{
+			throw ExceptionFactory.ForUsingPreviousControlVariable(forLine.LineNumber);
+		}
+
+		if (parent.Parent == null)
+		{
+			return;
+		}
+
+		ValidateNotUsingPreviousControlVariable(forLine, parent.Parent);
+	}
+
+	private bool ProcessForBlock(IEnvironment env, ProgramLine? parent)
+	{
+		if (!ProcessForLine(env, parent))
+		{
+			return false;
+		}
+		var forLine = env.Program.Last();
+		ValidateNotUsingPreviousControlVariable(forLine, parent);
+
+		while (true)
+		{
+			if (ProcessNextLine(env, forLine))
+			{
+				break;
+			}
+			if (!ProcessBlock(env, forLine))
+			{
+				break;
+			}
+		}
+
+		if (!(env.Program.Last().Statement is NextStatement))
+		{
+			throw ExceptionFactory.ForWithoutNext(forLine.LineNumber);
+		}
+
+		return true;
+	}
+
+	protected bool ProcessForLine(IEnvironment env, ProgramLine? parent)
+	{
+		var startIndex = _reader.TokenIndex;
+		if (_reader.IsAtEnd)
+		{
+			return false;
+		}
+
+		var lineNumber = ProcessLineNumber(false);
+		if (!lineNumber.HasValue)
+		{
+			_reader.Seek(startIndex);
+			return false;
+		}
+
+		if (ProcessSpace(false) == null)
+		{
+			// An empty line triggers a deletion.
+			env.Program.Delete(lineNumber.Value);
+			return true;
+		}
+
+		var statement = new ForStatementParser().Parse(_reader, lineNumber);
+		if (statement == null)
+		{
+			_reader.Seek(startIndex);
+			return false;
+		}
+
+		// Optional space.
+		ProcessSpace(false);
+
+		// Require an end-of-line.
+		ProcessEndOfLine();
+
+		env.Program.Insert(new ProgramLine(lineNumber.Value, statement, parent));
+		return true;
+	}
+
+	protected bool ProcessNextLine(IEnvironment env, ProgramLine? parent)
+	{
+		var startIndex = _reader.TokenIndex;
+		if (_reader.IsAtEnd)
+		{
+			return false;
+		}
+
+		var lineNumber = ProcessLineNumber(false);
+		if (!lineNumber.HasValue)
+		{
+			_reader.Seek(startIndex);
+			return false;
+		}
+
+		if (ProcessSpace(false) == null)
+		{
+			// An empty line triggers a deletion.
+			env.Program.Insert(new ProgramLine(lineNumber.Value, null, null));
+			return true;
+		}
+
+		var statement = new NextStatementParser().Parse(_reader, lineNumber);
+		if (statement == null)
+		{
+			_reader.Seek(startIndex);
+			return false;
+		}
+
+		if ((statement as NextStatement)!.LoopVar.Name != (parent!.Statement as ForStatement)!.LoopVar.Name)
+		{
+			throw ExceptionFactory.NextWithoutFor(lineNumber);
+		}
+
+		// Optional space.
+		ProcessSpace(false);
+
+		// Require an end-of-line.
+		ProcessEndOfLine();
+
+		env.Program.Insert(new ProgramLine(lineNumber.Value, statement, parent));
+		return true;
 	}
 }

--- a/src/ECMABasic.Core/NumericExpressionParser.cs
+++ b/src/ECMABasic.Core/NumericExpressionParser.cs
@@ -3,360 +3,359 @@ using ECMABasic.Core.Expressions;
 using System;
 using System.Collections.Generic;
 
-namespace ECMABasic.Core
+namespace ECMABasic.Core;
+
+public class NumericExpressionParser : ExpressionParser
 {
-	public class NumericExpressionParser : ExpressionParser
+	public NumericExpressionParser(ComplexTokenReader reader, int? lineNumber, bool throwOnError)
+		: base(reader, lineNumber, throwOnError)
 	{
-		public NumericExpressionParser(ComplexTokenReader reader, int? lineNumber, bool throwOnError)
-			: base(reader, lineNumber, throwOnError)
+	}
+
+	public override IExpression? Parse()
+	{
+		var expr = ParseBoolean();
+		return expr;
+	}
+
+	private IExpression? ParseBoolean()
+	{
+		var left = ParseSums();
+		if (left == null)
 		{
+			return null;
 		}
 
-		public override IExpression? Parse()
+		var space = _reader.Next(TokenType.Space, false);
+
+		var symbol = ParseBooleanOperator();
+		if (symbol == null)
 		{
-			var expr = ParseBoolean();
+			if (space != null)
+			{
+				_reader.Rewind();
+			}
+			return left;
+		}
+
+		_reader.Next(TokenType.Space, false);
+
+		IExpression? right;
+		try
+		{
+			right = ParseSums();
+		}
+		catch (SyntaxException)
+		{
+			if (new StringExpressionParser(_reader, _lineNumber, false).Parse() != null)
+			{
+				throw ExceptionFactory.MixedStringsAndNumbers(_lineNumber);
+			}
+			else
+			{
+				throw;
+			}
+		}
+
+		if (right == null)
+		{
+			throw ExceptionFactory.ExpectedNumericExpression(_lineNumber);
+		}
+
+		try
+		{
+			if (symbol.Text == "=")
+			{
+				return new EqualsExpression(left, right);
+			}
+			else if (symbol.Text == "<>")
+			{
+				return new NotEqualsExpression(left, right);
+			}
+			else if (symbol.Text == "<")
+			{
+				return new LessThanExpression(left, right);
+			}
+			else if (symbol.Text == "<=")
+			{
+				return new LessThanOrEqualExpression(left, right);
+			}
+			else if (symbol.Text == ">")
+			{
+				return new GreaterThanExpression(left, right);
+			}
+			else if (symbol.Text == ">=")
+			{
+				return new GreaterThanOrEqualExpression(left, right);
+			}
+			else
+			{
+				throw ExceptionFactory.IllegalOperator(_lineNumber);
+			}
+		}
+		catch (SyntaxException ex)
+		{
+			throw new SyntaxException(ex, _lineNumber);
+		}
+	}
+
+	private IExpression? ParseSums()
+	{
+		var expr = ParseProducts();
+		if (expr == null)
+		{
 			return expr;
 		}
 
-		private IExpression? ParseBoolean()
+		while (true)
 		{
-			var left = ParseSums();
-			if (left == null)
-			{
-				return null;
-			}
-
 			var space = _reader.Next(TokenType.Space, false);
 
-			var symbol = ParseBooleanOperator();
+			var preSymbolIndex = _reader.TokenIndex;
+			var symbol = _reader.Next(TokenType.Symbol, false, @"\+|\-");
 			if (symbol == null)
 			{
 				if (space != null)
 				{
 					_reader.Rewind();
 				}
-				return left;
+				return expr;
 			}
 
 			_reader.Next(TokenType.Space, false);
 
-			IExpression? right;
-			try
+			var right = ParseProducts();
+			if (right == null)
 			{
-				right = ParseSums();
-			}
-			catch (SyntaxException)
-			{
-				if (new StringExpressionParser(_reader, _lineNumber, false).Parse() != null)
-				{
-					throw ExceptionFactory.MixedStringsAndNumbers(_lineNumber);
-				}
-				else
-				{
-					throw;
-				}
+				_reader.Seek(preSymbolIndex);
+				return expr;
 			}
 
+			expr = symbol.Text switch
+			{
+				"+" => new AdditionExpression(expr, right),
+				"-" => new SubtractionExpression(expr, right),
+				_ => throw ExceptionFactory.IllegalOperator(_lineNumber),
+			};
+		}
+	}
+
+	private IExpression? ParseProducts()
+	{
+		var expr = ParseUnary();
+		if (expr == null)
+		{
+			return expr;
+		}
+
+		while (true)
+		{
+			var space = _reader.Next(TokenType.Space, false);
+
+			var preSymbolIndex = _reader.TokenIndex;
+			var symbol = _reader.Next(TokenType.Symbol, false, @"\*|\/");
+			if (symbol == null)
+			{
+				if (space != null)
+				{
+					_reader.Rewind();
+				}
+				return expr;
+			}
+
+			_reader.Next(TokenType.Space, false);
+
+			var right = ParseUnary();
 			if (right == null)
+			{
+				_reader.Seek(preSymbolIndex);
+				return expr;
+			}
+
+			expr = symbol.Text switch
+			{
+				"*" => new MultiplicationExpression(expr, right),
+				"/" => new DivisionExpression(expr, right),
+				_ => throw ExceptionFactory.IllegalOperator(_lineNumber),
+			};
+		}
+	}
+
+	private IExpression? ParseUnary()
+	{
+		var unaryMinusToken = _reader.Next(TokenType.Symbol, false, @"\-");
+		if (unaryMinusToken == null)
+		{
+			// Read the unary plus if it's there, but don't do anything with it.
+			_reader.Next(TokenType.Symbol, false, @"\+");
+		}
+
+		_reader.Next(TokenType.Space, false);
+
+		var expr = ParseInvolution();
+		if (unaryMinusToken != null)
+		{
+			if (expr == null)
 			{
 				throw ExceptionFactory.ExpectedNumericExpression(_lineNumber);
 			}
-
-			try
-			{
-				if (symbol.Text == "=")
-				{
-					return new EqualsExpression(left, right);
-				}
-				else if (symbol.Text == "<>")
-				{
-					return new NotEqualsExpression(left, right);
-				}
-				else if (symbol.Text == "<")
-				{
-					return new LessThanExpression(left, right);
-				}
-				else if (symbol.Text == "<=")
-				{
-					return new LessThanOrEqualExpression(left, right);
-				}
-				else if (symbol.Text == ">")
-				{
-					return new GreaterThanExpression(left, right);
-				}
-				else if (symbol.Text == ">=")
-				{
-					return new GreaterThanOrEqualExpression(left, right);
-				}
-				else
-				{
-					throw ExceptionFactory.IllegalOperator(_lineNumber);
-				}
-			}
-			catch (SyntaxException ex)
-			{
-				throw new SyntaxException(ex, _lineNumber);
-			}
+			expr = new NegationExpression(expr);
 		}
 
-		private IExpression? ParseSums()
+		return expr;
+	}
+
+	private IExpression? ParseInvolution()
+	{
+		var expr = ParseAtomic(false);
+		if (expr == null)
 		{
-			var expr = ParseProducts();
-			if (expr == null)
+			return expr;
+		}
+
+		while (true)
+		{
+			var space = _reader.Next(TokenType.Space, false);
+
+			var preSymbolIndex = _reader.TokenIndex;
+			var symbol = _reader.Next(TokenType.Symbol, false, @"\^|\*");
+			if (symbol == null)
 			{
+				if (space != null)
+				{
+					_reader.Rewind();
+				}
 				return expr;
 			}
-
-			while (true)
+			else if (symbol.Text == "*")
 			{
-				var space = _reader.Next(TokenType.Space, false);
-
-				var preSymbolIndex = _reader.TokenIndex;
-				var symbol = _reader.Next(TokenType.Symbol, false, @"\+|\-");
-				if (symbol == null)
+				var next = _reader.Next(TokenType.Symbol, false, @"\*");
+				if (next == null)
 				{
-					if (space != null)
-					{
-						_reader.Rewind();
-					}
+					_reader.Rewind();
 					return expr;
 				}
-
-				_reader.Next(TokenType.Space, false);
-
-				var right = ParseProducts();
-				if (right == null)
-				{
-					_reader.Seek(preSymbolIndex);
-					return expr;
-				}
-
-				expr = symbol.Text switch
-				{
-					"+" => new AdditionExpression(expr, right),
-					"-" => new SubtractionExpression(expr, right),
-					_ => throw ExceptionFactory.IllegalOperator(_lineNumber),
-				};
-			}
-		}
-
-		private IExpression? ParseProducts()
-		{
-			var expr = ParseUnary();
-			if (expr == null)
-			{
-				return expr;
-			}
-
-			while (true)
-			{
-				var space = _reader.Next(TokenType.Space, false);
-
-				var preSymbolIndex = _reader.TokenIndex;
-				var symbol = _reader.Next(TokenType.Symbol, false, @"\*|\/");
-				if (symbol == null)
-				{
-					if (space != null)
-					{
-						_reader.Rewind();
-					}
-					return expr;
-				}
-
-				_reader.Next(TokenType.Space, false);
-
-				var right = ParseUnary();
-				if (right == null)
-				{
-					_reader.Seek(preSymbolIndex);
-					return expr;
-				}
-
-				expr = symbol.Text switch
-				{
-					"*" => new MultiplicationExpression(expr, right),
-					"/" => new DivisionExpression(expr, right),
-					_ => throw ExceptionFactory.IllegalOperator(_lineNumber),
-				};
-			}
-		}
-
-		private IExpression? ParseUnary()
-		{
-			var unaryMinusToken = _reader.Next(TokenType.Symbol, false, @"\-");
-			if (unaryMinusToken == null)
-			{
-				// Read the unary plus if it's there, but don't do anything with it.
-				_reader.Next(TokenType.Symbol, false, @"\+");
+				// At this point we've read the "**" operator.
 			}
 
 			_reader.Next(TokenType.Space, false);
 
-			var expr = ParseInvolution();
-			if (unaryMinusToken != null)
+			var right = ParseAtomic(true);
+			if (right == null)
 			{
-				if (expr == null)
+				_reader.Seek(preSymbolIndex);
+				return expr;
+			}
+
+			expr = new InvolutionExpression(expr, right);
+		}
+	}
+
+	private IExpression? ParseAtomic(bool throwOnError)
+	{
+		var openParenthesis = _reader.Next(TokenType.OpenParenthesis, false);
+		if (openParenthesis != null)
+		{
+			var expr = Parse();
+			try
+			{
+				_reader.Next(TokenType.CloseParenthesis);
+			}
+			catch (UnexpectedTokenException)
+			{
+				throw ExceptionFactory.IllegalFormula(_lineNumber);
+			}
+			return expr;
+		}
+		else
+		{
+			var expr = ParseLiteral() ?? ParseVariable() ?? ParseFunction(throwOnError);
+			if (expr == null)
+			{
+				if (throwOnError)
 				{
 					throw ExceptionFactory.ExpectedNumericExpression(_lineNumber);
 				}
-				expr = new NegationExpression(expr);
+				else
+				{
+					return expr;
+				}
 			}
 
 			return expr;
 		}
+	}
 
-		private IExpression? ParseInvolution()
+	public IExpression? ParseVariable()
+	{
+		var nameToken = _reader.Next(TokenType.Word, false, @"[A-Z]\d?");
+		if (nameToken == null)
 		{
-			var expr = ParseAtomic(false);
-			if (expr == null)
-			{
-				return expr;
-			}
-
-			while (true)
-			{
-				var space = _reader.Next(TokenType.Space, false);
-
-				var preSymbolIndex = _reader.TokenIndex;
-				var symbol = _reader.Next(TokenType.Symbol, false, @"\^|\*");
-				if (symbol == null)
-				{
-					if (space != null)
-					{
-						_reader.Rewind();
-					}
-					return expr;
-				}
-				else if (symbol.Text == "*")
-				{
-					var next = _reader.Next(TokenType.Symbol, false, @"\*");
-					if (next == null)
-					{
-						_reader.Rewind();
-						return expr;
-					}
-					// At this point we've read the "**" operator.
-				}
-
-				_reader.Next(TokenType.Space, false);
-
-				var right = ParseAtomic(true);
-				if (right == null)
-				{
-					_reader.Seek(preSymbolIndex);
-					return expr;
-				}
-
-				expr = new InvolutionExpression(expr, right);
-			}
+			return null;
 		}
 
-		private IExpression? ParseAtomic(bool throwOnError)
-		{
-			var openParenthesis = _reader.Next(TokenType.OpenParenthesis, false);
-			if (openParenthesis != null)
-			{
-				var expr = Parse();
-				try
-				{
-					_reader.Next(TokenType.CloseParenthesis);
-				}
-				catch (UnexpectedTokenException)
-				{
-					throw ExceptionFactory.IllegalFormula(_lineNumber);
-				}
-				return expr;
-			}
-			else
-			{
-				var expr = ParseLiteral() ?? ParseVariable() ?? ParseFunction(throwOnError);
-				if (expr == null)
-				{
-					if (throwOnError)
-					{
-						throw ExceptionFactory.ExpectedNumericExpression(_lineNumber);
-					}
-					else
-					{
-						return expr;
-					}
-				}
+		return new VariableExpression(nameToken.Text);
+	}
 
-				return expr;
-			}
+	public IExpression? ParseLiteral()
+	{
+		var nextValue = _reader.NextNumber(false);
+		if (!nextValue.HasValue)
+		{
+			return null;
+		}
+		return new NumberExpression(nextValue.Value);
+	}
+
+	public IExpression? ParseFunction(bool throwOnError)
+	{
+		var nameToken = _reader.Next(TokenType.Word, false);
+		if (nameToken == null)
+		{
+			return null;
 		}
 
-		public IExpression? ParseVariable()
+		_reader.Next(TokenType.OpenParenthesis);
+
+		var args = new List<IExpression>();
+		while (true)
 		{
-			var nameToken = _reader.Next(TokenType.Word, false, @"[A-Z]\d?");
-			if (nameToken == null)
+			var argExpr = new StringExpressionParser(_reader, _lineNumber, false).Parse();
+			if (argExpr == null)
 			{
-				return null;
-			}
-
-			return new VariableExpression(nameToken.Text);
-		}
-
-		public IExpression? ParseLiteral()
-		{
-			var nextValue = _reader.NextNumber(false);
-			if (!nextValue.HasValue)
-			{
-				return null;
-			}
-			return new NumberExpression(nextValue.Value);
-		}
-
-		public IExpression? ParseFunction(bool throwOnError)
-		{
-			var nameToken = _reader.Next(TokenType.Word, false);
-			if (nameToken == null)
-			{
-				return null;
-			}
-
-			_reader.Next(TokenType.OpenParenthesis);
-
-			var args = new List<IExpression>();
-			while (true)
-			{
-				var argExpr = new StringExpressionParser(_reader, _lineNumber, false).Parse();
+				argExpr = Parse();
 				if (argExpr == null)
-				{
-					argExpr = Parse();
-					if (argExpr == null)
-					{
-						break;
-					}
-				}
-
-				args.Add(argExpr);
-
-				var comma = _reader.Next(TokenType.Comma, false);
-				if (comma == null)
 				{
 					break;
 				}
 			}
 
-			_reader.Next(TokenType.CloseParenthesis);
+			args.Add(argExpr);
 
-			foreach (var fndef in FunctionFactory.Instance.Get(nameToken.Text))
+			var comma = _reader.Next(TokenType.Comma, false);
+			if (comma == null)
 			{
-				if (fndef.CanInstantiate(args))
-				{
-					return fndef.Instantiate(args, _lineNumber);
-				}
+				break;
 			}
+		}
 
-			if (throwOnError)
+		_reader.Next(TokenType.CloseParenthesis);
+
+		foreach (var fndef in FunctionFactory.Instance.Get(nameToken.Text))
+		{
+			if (fndef.CanInstantiate(args))
 			{
-				throw ExceptionFactory.UndefinedFunction(_lineNumber);
+				return fndef.Instantiate(args, _lineNumber);
 			}
-			else
-			{
-				return null;
-			}
+		}
+
+		if (throwOnError)
+		{
+			throw ExceptionFactory.UndefinedFunction(_lineNumber);
+		}
+		else
+		{
+			return null;
 		}
 	}
 }

--- a/src/ECMABasic.Core/Parsers/DataStatementParser.cs
+++ b/src/ECMABasic.Core/Parsers/DataStatementParser.cs
@@ -3,81 +3,80 @@ using ECMABasic.Core.Expressions;
 using ECMABasic.Core.Statements;
 using System.Collections.Generic;
 
-namespace ECMABasic.Core.Parsers
+namespace ECMABasic.Core.Parsers;
+
+public class DataStatementParser : StatementParser
 {
-	public class DataStatementParser : StatementParser
+	public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
 	{
-		public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
+		var token = reader.Next(TokenType.Word, false, "DATA");
+		if (token == null)
 		{
-			var token = reader.Next(TokenType.Word, false, "DATA");
-			if (token == null)
+			return null;
+		}
+		ProcessSpace(reader, true);
+
+		var datums = new List<IExpression>();
+
+		while (true)
+		{
+			ProcessSpace(reader, false);
+
+			token = reader.Next(TokenType.String, false);
+			if (token != null)
 			{
-				return null;
+				datums.Add(new StringExpression(token.Text[1..^1]));
 			}
-			ProcessSpace(reader, true);
-
-			var datums = new List<IExpression>();
-
-			while (true)
+			else
 			{
-				ProcessSpace(reader, false);
-
-				token = reader.Next(TokenType.String, false);
-				if (token != null)
+				var value = reader.NextNumber(false);
+				if (value.HasValue)
 				{
-					datums.Add(new StringExpression(token.Text[1..^1]));
+					datums.Add(new NumberExpression(value.Value));
 				}
 				else
 				{
-					var value = reader.NextNumber(false);
-					if (value.HasValue)
-					{
-						datums.Add(new NumberExpression(value.Value));
-					}
-					else
-					{
-						// Read an unquoted string.
+					// Read an unquoted string.
 
-						token = null;
-						var delimiters = new[] { TokenType.EndOfLine, TokenType.Comma };
-						while (true)
+					token = null;
+					var delimiters = new[] { TokenType.EndOfLine, TokenType.Comma };
+					while (true)
+					{
+						var next = reader.Peek();
+						if ((next == null) || (next.Type == TokenType.EndOfLine) || (next.Type == TokenType.Comma) || ((next.Type == TokenType.Symbol) && (next.Text == ",")))
 						{
-							var next = reader.Peek();
-							if ((next == null) || (next.Type == TokenType.EndOfLine) || (next.Type == TokenType.Comma) || ((next.Type == TokenType.Symbol) && (next.Text == ",")))
-							{
-								break;
-							} 
-
-							if (token == null)
-							{
-								token = reader.Next();
-							}
-							else
-							{
-								var nextToken = reader.Next();
-							if (nextToken != null)
-							{
-								token = new Token(TokenType.String, new[] { token, nextToken });
-							}
-							}
-						}
+							break;
+						} 
 
 						if (token == null)
 						{
-							throw new SyntaxException("SYNTAX ERROR", lineNumber);
+							token = reader.Next();
 						}
-						datums.Add(new StringExpression(token.Text.Trim()));
+						else
+						{
+							var nextToken = reader.Next();
+						if (nextToken != null)
+						{
+							token = new Token(TokenType.String, new[] { token, nextToken });
+						}
+						}
 					}
-				}
 
-				ProcessSpace(reader, false);
-				if (reader.Next(TokenType.Comma, false) == null)
-				{
-					break;
+					if (token == null)
+					{
+						throw new SyntaxException("SYNTAX ERROR", lineNumber);
+					}
+					datums.Add(new StringExpression(token.Text.Trim()));
 				}
 			}
 
-			return new DataStatement(datums);
+			ProcessSpace(reader, false);
+			if (reader.Next(TokenType.Comma, false) == null)
+			{
+				break;
+			}
 		}
+
+		return new DataStatement(datums);
 	}
 }

--- a/src/ECMABasic.Core/Parsers/EndStatementParser.cs
+++ b/src/ECMABasic.Core/Parsers/EndStatementParser.cs
@@ -1,17 +1,16 @@
 ﻿using ECMABasic.Core.Statements;
 
-namespace ECMABasic.Core
+namespace ECMABasic.Core;
+
+public class EndStatementParser : StatementParser
 {
-	public class EndStatementParser : StatementParser
+	public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
 	{
-		public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
+		var token = reader.Next(TokenType.Word, false, "END");
+		if (token == null)
 		{
-			var token = reader.Next(TokenType.Word, false, "END");
-			if (token == null)
-			{
-				return null;
-			}
-			return new EndStatement();
+			return null;
 		}
+		return new EndStatement();
 	}
 }

--- a/src/ECMABasic.Core/Parsers/ForStatementParser.cs
+++ b/src/ECMABasic.Core/Parsers/ForStatementParser.cs
@@ -1,64 +1,63 @@
 ﻿using ECMABasic.Core.Expressions;
 using ECMABasic.Core.Statements;
 
-namespace ECMABasic.Core.Parsers
+namespace ECMABasic.Core.Parsers;
+
+public class ForStatementParser : StatementParser
 {
-	public class ForStatementParser : StatementParser
+	public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
 	{
-		public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
+		var token = reader.Next(TokenType.Word, false, @"FOR");
+		if (token == null)
 		{
-			var token = reader.Next(TokenType.Word, false, @"FOR");
-			if (token == null)
-			{
-				return null;
-			}
-
-			ProcessSpace(reader, true);
-
-			var loopVar = ParseVariableExpression(reader);
-			if (loopVar == null)
-			{
-				throw new Exceptions.SyntaxException("Expected variable in FOR statement", lineNumber);
-			}
-
-			ProcessSpace(reader, false);
-			reader.Next(TokenType.Symbol, true, @"\=");
-			ProcessSpace(reader, false);
-
-			var from = ParseNumericExpression(reader, lineNumber, true);
-			if (from == null)
-			{
-				throw new Exceptions.SyntaxException("Expected FROM expression in FOR statement", lineNumber);
-			}
-
-			ProcessSpace(reader, true);
-			reader.Next(TokenType.Word, true, "TO");
-			ProcessSpace(reader, true);
-
-			var to = ParseNumericExpression(reader, lineNumber, true);
-			if (to == null)
-			{
-				throw new Exceptions.SyntaxException("Expected TO expression in FOR statement", lineNumber);
-			}
-
-			IExpression step;
-			ProcessSpace(reader, false);
-			token = reader.Next(TokenType.Word, false, "STEP");
-			if (token != null)
-			{
-				ProcessSpace(reader, true);
-				var stepExpr = ParseNumericExpression(reader, lineNumber, true);
-				if (stepExpr == null)
-				{
-					throw new Exceptions.SyntaxException("Expected STEP expression in FOR statement", lineNumber);
-				}
-				step = stepExpr;
-			}
-			else
-			{
-				step = new NumberExpression(1);
-			}
-			return new ForStatement(loopVar, from, to, step);
+			return null;
 		}
+
+		ProcessSpace(reader, true);
+
+		var loopVar = ParseVariableExpression(reader);
+		if (loopVar == null)
+		{
+			throw new Exceptions.SyntaxException("Expected variable in FOR statement", lineNumber);
+		}
+
+		ProcessSpace(reader, false);
+		reader.Next(TokenType.Symbol, true, @"\=");
+		ProcessSpace(reader, false);
+
+		var from = ParseNumericExpression(reader, lineNumber, true);
+		if (from == null)
+		{
+			throw new Exceptions.SyntaxException("Expected FROM expression in FOR statement", lineNumber);
+		}
+
+		ProcessSpace(reader, true);
+		reader.Next(TokenType.Word, true, "TO");
+		ProcessSpace(reader, true);
+
+		var to = ParseNumericExpression(reader, lineNumber, true);
+		if (to == null)
+		{
+			throw new Exceptions.SyntaxException("Expected TO expression in FOR statement", lineNumber);
+		}
+
+		IExpression step;
+		ProcessSpace(reader, false);
+		token = reader.Next(TokenType.Word, false, "STEP");
+		if (token != null)
+		{
+			ProcessSpace(reader, true);
+			var stepExpr = ParseNumericExpression(reader, lineNumber, true);
+			if (stepExpr == null)
+			{
+				throw new Exceptions.SyntaxException("Expected STEP expression in FOR statement", lineNumber);
+			}
+			step = stepExpr;
+		}
+		else
+		{
+			step = new NumberExpression(1);
+		}
+		return new ForStatement(loopVar, from, to, step);
 	}
 }

--- a/src/ECMABasic.Core/Parsers/GosubStatementParser.cs
+++ b/src/ECMABasic.Core/Parsers/GosubStatementParser.cs
@@ -1,35 +1,34 @@
 ﻿using ECMABasic.Core.Statements;
 
-namespace ECMABasic.Core.Parsers
+namespace ECMABasic.Core.Parsers;
+
+public class GosubStatementParser : StatementParser
 {
-	public class GosubStatementParser : StatementParser
+	public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
 	{
-		public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
+		var token = reader.Next(TokenType.Word, false, @"GOSUB");
+		if (token == null)
 		{
-			var token = reader.Next(TokenType.Word, false, @"GOSUB");
+			// "GOSUB" might be "GO SUB".
+			token = reader.Next(TokenType.Word, false, @"GO");
 			if (token == null)
 			{
-				// "GOSUB" might be "GO SUB".
-				token = reader.Next(TokenType.Word, false, @"GO");
-				if (token == null)
-				{
-					return null;
-				}
-				else
-				{
-					ProcessSpace(reader, false);
-					reader.Next(TokenType.Word, true, @"SUB");
-				}
+				return null;
 			}
-
-			ProcessSpace(reader, true);
-
-			var lineNumberExpr = ParseNumericExpression(reader, lineNumber, true);
-			if (lineNumberExpr == null)
+			else
 			{
-				throw new Exceptions.SyntaxException("Expected line number in GOSUB statement", lineNumber);
+				ProcessSpace(reader, false);
+				reader.Next(TokenType.Word, true, @"SUB");
 			}
-			return new GosubStatement(lineNumberExpr);
 		}
+
+		ProcessSpace(reader, true);
+
+		var lineNumberExpr = ParseNumericExpression(reader, lineNumber, true);
+		if (lineNumberExpr == null)
+		{
+			throw new Exceptions.SyntaxException("Expected line number in GOSUB statement", lineNumber);
+		}
+		return new GosubStatement(lineNumberExpr);
 	}
 }

--- a/src/ECMABasic.Core/Parsers/GotoStatementParser.cs
+++ b/src/ECMABasic.Core/Parsers/GotoStatementParser.cs
@@ -1,33 +1,32 @@
 ﻿using ECMABasic.Core.Statements;
 
-namespace ECMABasic.Core.Parsers
+namespace ECMABasic.Core.Parsers;
+
+public class GotoStatementParser : StatementParser
 {
-	public class GotoStatementParser : StatementParser
+	public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
 	{
-		public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
+		if (reader.Next(TokenType.Word, false, @"GOTO") == null)
 		{
-			if (reader.Next(TokenType.Word, false, @"GOTO") == null)
+			// "GOTO" might be "GO TO".
+			if (reader.Next(TokenType.Word, false, @"GO") == null)
 			{
-				// "GOTO" might be "GO TO".
-				if (reader.Next(TokenType.Word, false, @"GO") == null)
-				{
-					return null;
-				}
-				else
-				{
-					ProcessSpace(reader, false);
-					reader.Next(TokenType.Word, true, @"TO");
-				}
+				return null;
 			}
-
-			ProcessSpace(reader, true);
-
-			var lineNumberExpr = ParseNumericExpression(reader, lineNumber, true);
-			if (lineNumberExpr == null)
+			else
 			{
-				throw new Exceptions.SyntaxException("Expected line number in GOTO statement", lineNumber);
+				ProcessSpace(reader, false);
+				reader.Next(TokenType.Word, true, @"TO");
 			}
-			return new GotoStatement(lineNumberExpr);
 		}
+
+		ProcessSpace(reader, true);
+
+		var lineNumberExpr = ParseNumericExpression(reader, lineNumber, true);
+		if (lineNumberExpr == null)
+		{
+			throw new Exceptions.SyntaxException("Expected line number in GOTO statement", lineNumber);
+		}
+		return new GotoStatement(lineNumberExpr);
 	}
 }

--- a/src/ECMABasic.Core/Parsers/IfThenStatementParser.cs
+++ b/src/ECMABasic.Core/Parsers/IfThenStatementParser.cs
@@ -1,37 +1,36 @@
 ﻿using ECMABasic.Core.Statements;
 
-namespace ECMABasic.Core.Parsers
+namespace ECMABasic.Core.Parsers;
+
+public class IfThenStatementParser : StatementParser
 {
-	public class IfThenStatementParser : StatementParser
+	public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
 	{
-		public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
+		if (reader.Next(TokenType.Word, false, @"IF") == null)
 		{
-			if (reader.Next(TokenType.Word, false, @"IF") == null)
-			{
-				return null;
-			}
-
-			ProcessSpace(reader, true);
-
-			var conditionExpr = ParseExpression(reader, lineNumber, true);
-			if (conditionExpr == null)
-			{
-				throw ExceptionFactory.ExpectedConditionalExpression(lineNumber);
-			}
-
-			ProcessSpace(reader, true);
-
-			reader.Next(TokenType.Word, true, @"THEN");
-
-			ProcessSpace(reader, true);
-
-			var lineNumberExpr = ParseExpression(reader, lineNumber, true);
-			if (lineNumberExpr == null)
-			{
-				throw ExceptionFactory.ExpectedNumericExpression(lineNumber);
-			}
-
-			return new IfThenStatement(conditionExpr, lineNumberExpr);
+			return null;
 		}
+
+		ProcessSpace(reader, true);
+
+		var conditionExpr = ParseExpression(reader, lineNumber, true);
+		if (conditionExpr == null)
+		{
+			throw ExceptionFactory.ExpectedConditionalExpression(lineNumber);
+		}
+
+		ProcessSpace(reader, true);
+
+		reader.Next(TokenType.Word, true, @"THEN");
+
+		ProcessSpace(reader, true);
+
+		var lineNumberExpr = ParseExpression(reader, lineNumber, true);
+		if (lineNumberExpr == null)
+		{
+			throw ExceptionFactory.ExpectedNumericExpression(lineNumber);
+		}
+
+		return new IfThenStatement(conditionExpr, lineNumberExpr);
 	}
 }

--- a/src/ECMABasic.Core/Parsers/InputStatementParser.cs
+++ b/src/ECMABasic.Core/Parsers/InputStatementParser.cs
@@ -2,42 +2,41 @@
 using ECMABasic.Core.Statements;
 using System.Collections.Generic;
 
-namespace ECMABasic.Core.Parsers
+namespace ECMABasic.Core.Parsers;
+
+public class InputStatementParser : StatementParser
 {
-	public class InputStatementParser : StatementParser
+	public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
 	{
-		public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
+		var token = reader.Next(TokenType.Word, false, "INPUT");
+		if (token == null)
 		{
-			var token = reader.Next(TokenType.Word, false, "INPUT");
-			if (token == null)
-			{
-				return null;
-			}
-			ProcessSpace(reader, true);
-
-			var firstVar = ParseVariableExpression(reader);
-			if (firstVar == null)
-			{
-				throw new Exceptions.SyntaxException("Expected variable in INPUT statement", lineNumber);
-			}
-
-			var vars = new List<VariableExpression> { firstVar };
-
-			while (true)
-			{
-				if (reader.Next(TokenType.Comma, false) == null)
-				{
-					break;
-				}
-				ProcessSpace(reader, false);
-				var nextVar = ParseVariableExpression(reader);
-				if (nextVar != null)
-				{
-					vars.Add(nextVar);
-				}
-			}
-
-			return new InputStatement(vars);
+			return null;
 		}
+		ProcessSpace(reader, true);
+
+		var firstVar = ParseVariableExpression(reader);
+		if (firstVar == null)
+		{
+			throw new Exceptions.SyntaxException("Expected variable in INPUT statement", lineNumber);
+		}
+
+		var vars = new List<VariableExpression> { firstVar };
+
+		while (true)
+		{
+			if (reader.Next(TokenType.Comma, false) == null)
+			{
+				break;
+			}
+			ProcessSpace(reader, false);
+			var nextVar = ParseVariableExpression(reader);
+			if (nextVar != null)
+			{
+				vars.Add(nextVar);
+			}
+		}
+
+		return new InputStatement(vars);
 	}
 }

--- a/src/ECMABasic.Core/Parsers/LetStatementParser.cs
+++ b/src/ECMABasic.Core/Parsers/LetStatementParser.cs
@@ -1,42 +1,41 @@
 ﻿using ECMABasic.Core.Exceptions;
 using ECMABasic.Core.Statements;
 
-namespace ECMABasic.Core
+namespace ECMABasic.Core;
+
+public class LetStatementParser : StatementParser
 {
-	public class LetStatementParser : StatementParser
+	public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
 	{
-		public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
+		var token = reader.Next(TokenType.Word, false, "LET");
+		if (token == null)
 		{
-			var token = reader.Next(TokenType.Word, false, "LET");
-			if (token == null)
-			{
-				return null;
-			}
-
-			ProcessSpace(reader, true);
-
-			var targetExpr = ParseVariableExpression(reader);
-			if (targetExpr == null)
-			{
-				throw ExceptionFactory.ExpectedVariable(lineNumber);
-			}
-
-			ProcessSpace(reader, false);
-
-			reader.Next(TokenType.Symbol, true, @"\=");
-
-			ProcessSpace(reader, false);
-
-			var valueExpr = targetExpr.IsNumeric
-				? ParseNumericExpression(reader, lineNumber, true)
-				: ParseStringExpression(reader, lineNumber, true);
-
-			if (valueExpr == null)
-			{
-				throw new Exceptions.SyntaxException("Expected expression in LET statement", lineNumber);
-			}
-
-			return new LetStatement(targetExpr, valueExpr);
+			return null;
 		}
+
+		ProcessSpace(reader, true);
+
+		var targetExpr = ParseVariableExpression(reader);
+		if (targetExpr == null)
+		{
+			throw ExceptionFactory.ExpectedVariable(lineNumber);
+		}
+
+		ProcessSpace(reader, false);
+
+		reader.Next(TokenType.Symbol, true, @"\=");
+
+		ProcessSpace(reader, false);
+
+		var valueExpr = targetExpr.IsNumeric
+			? ParseNumericExpression(reader, lineNumber, true)
+			: ParseStringExpression(reader, lineNumber, true);
+
+		if (valueExpr == null)
+		{
+			throw new Exceptions.SyntaxException("Expected expression in LET statement", lineNumber);
+		}
+
+		return new LetStatement(targetExpr, valueExpr);
 	}
 }

--- a/src/ECMABasic.Core/Parsers/NextStatementParser.cs
+++ b/src/ECMABasic.Core/Parsers/NextStatementParser.cs
@@ -1,26 +1,25 @@
 ﻿using ECMABasic.Core.Statements;
 
-namespace ECMABasic.Core.Parsers
+namespace ECMABasic.Core.Parsers;
+
+public class NextStatementParser : StatementParser
 {
-	public class NextStatementParser : StatementParser
+	public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
 	{
-		public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
+		var token = reader.Next(TokenType.Word, false, @"NEXT");
+		if (token == null)
 		{
-			var token = reader.Next(TokenType.Word, false, @"NEXT");
-			if (token == null)
-			{
-				return null;
-			}
-
-			ProcessSpace(reader, true);
-
-			var loopVar = ParseVariableExpression(reader);
-			if (loopVar == null)
-			{
-				throw new Exceptions.SyntaxException("Expected variable in NEXT statement", lineNumber);
-			}
-
-			return new NextStatement(loopVar);
+			return null;
 		}
+
+		ProcessSpace(reader, true);
+
+		var loopVar = ParseVariableExpression(reader);
+		if (loopVar == null)
+		{
+			throw new Exceptions.SyntaxException("Expected variable in NEXT statement", lineNumber);
+		}
+
+		return new NextStatement(loopVar);
 	}
 }

--- a/src/ECMABasic.Core/Parsers/OnGotoStatementParser.cs
+++ b/src/ECMABasic.Core/Parsers/OnGotoStatementParser.cs
@@ -6,69 +6,68 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace ECMABasic.Core.Parsers
+namespace ECMABasic.Core.Parsers;
+
+public class OnGotoStatementParser : StatementParser
 {
-	public class OnGotoStatementParser : StatementParser
+	public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
 	{
-		public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
+		if (reader.Next(TokenType.Word, false, @"ON") == null)
 		{
-			if (reader.Next(TokenType.Word, false, @"ON") == null)
+			return null;
+		}
+
+		ProcessSpace(reader, true);
+		var value = ParseNumericExpression(reader, lineNumber, true);
+		if (value == null)
+		{
+			throw new SyntaxException("Expected numeric expression in ON GOTO statement", lineNumber);
+		}
+		ProcessSpace(reader, true);
+
+		if (reader.Next(TokenType.Word, false, @"GOTO") == null)
+		{
+			// "GOTO" might be "GO TO".
+			if (reader.Next(TokenType.Word, false, @"GO") == null)
 			{
 				return null;
 			}
-
-			ProcessSpace(reader, true);
-			var value = ParseNumericExpression(reader, lineNumber, true);
-			if (value == null)
-			{
-				throw new SyntaxException("Expected numeric expression in ON GOTO statement", lineNumber);
-			}
-			ProcessSpace(reader, true);
-
-			if (reader.Next(TokenType.Word, false, @"GOTO") == null)
-			{
-				// "GOTO" might be "GO TO".
-				if (reader.Next(TokenType.Word, false, @"GO") == null)
-				{
-					return null;
-				}
-				else
-				{
-					ProcessSpace(reader, false);
-					reader.Next(TokenType.Word, true, @"TO");
-				}
-			}
-
-			ProcessSpace(reader, true);
-
-			var branches = new List<IExpression>();
-
-			while (true)
+			else
 			{
 				ProcessSpace(reader, false);
-				var lineNumberExpr = ParseNumericExpression(reader, lineNumber, false);
-				if (lineNumberExpr == null)
-				{
-					break;
-				}
-				branches.Add(lineNumberExpr);
-
-				ProcessSpace(reader, false);
-				var comma = reader.Next(TokenType.Comma, false);
-				if (comma == null)
-				{
-					break;
-				}
-				// There was a comma, so continue to the next line number.
+				reader.Next(TokenType.Word, true, @"TO");
 			}
-
-			if (branches.Count == 0)
-			{
-				throw ExceptionFactory.LineNumberExpected();
-			}
-
-
-			return new OnGotoStatement(value, branches);
 		}
+
+		ProcessSpace(reader, true);
+
+		var branches = new List<IExpression>();
+
+		while (true)
+		{
+			ProcessSpace(reader, false);
+			var lineNumberExpr = ParseNumericExpression(reader, lineNumber, false);
+			if (lineNumberExpr == null)
+			{
+				break;
+			}
+			branches.Add(lineNumberExpr);
+
+			ProcessSpace(reader, false);
+			var comma = reader.Next(TokenType.Comma, false);
+			if (comma == null)
+			{
+				break;
+			}
+			// There was a comma, so continue to the next line number.
+		}
+
+		if (branches.Count == 0)
+		{
+			throw ExceptionFactory.LineNumberExpected();
+		}
+
+
+		return new OnGotoStatement(value, branches);
 	}
 }

--- a/src/ECMABasic.Core/Parsers/PrintStatementParser.cs
+++ b/src/ECMABasic.Core/Parsers/PrintStatementParser.cs
@@ -2,113 +2,112 @@
 using ECMABasic.Core.Statements;
 using System.Collections.Generic;
 
-namespace ECMABasic.Core
+namespace ECMABasic.Core;
+
+public class PrintStatementParser : StatementParser
 {
-	public class PrintStatementParser : StatementParser
+	public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
 	{
-		public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
+		var token = reader.Next(TokenType.Word, false, "PRINT");
+		if (token == null)
 		{
-			var token = reader.Next(TokenType.Word, false, "PRINT");
-			if (token == null)
-			{
-				return null;
-			}
-
-			var spaceToken = ProcessSpace(reader, false);
-			if (spaceToken == null)
-			{
-				// It's just an empty print statement.
-				return new PrintStatement();
-			}
-
-			var printList = ProcessPrintList(reader, lineNumber);
-			return new PrintStatement(printList);
-		}
-
-		private static List<IPrintItem> ProcessPrintList(ComplexTokenReader reader, int? lineNumber = null)
-		{
-			var items = new List<IPrintItem>();
-
-			while (true)
-			{
-				var printItem = ProcessPrintItem(reader, lineNumber);
-				if (printItem != null)
-				{
-					items.Add(printItem);
-				}
-
-				ProcessSpace(reader, false);  // Optional space.
-
-				var printSeparator = ProcessPrintSeparator(reader);
-
-				ProcessSpace(reader, false);  // Optional space.
-
-				if (printSeparator == null)
-				{
-					// No separator, so this is the end of the list.
-					return items;
-				}
-				else
-				{
-					// If there's a separator, there might be another item.
-					items.Add(printSeparator);
-				}
-			}
-		}
-
-		private static IPrintItemSeparator? ProcessPrintSeparator(ComplexTokenReader reader)
-		{
-			var symbolToken = reader.Next(TokenType.Comma, false);
-			if (symbolToken != null)
-			{
-				return new CommaExpression();
-			}
-
-			symbolToken = reader.Next(TokenType.Semicolon, false);
-			if (symbolToken != null)
-			{
-				return new SemicolonExpression();
-			}
-
 			return null;
 		}
 
-		private static IPrintItem? ProcessPrintItem(ComplexTokenReader reader, int? lineNumber = null)
+		var spaceToken = ProcessSpace(reader, false);
+		if (spaceToken == null)
 		{
-			var expr = ProcessTabExpression(reader, lineNumber);
-			if (expr != null)
+			// It's just an empty print statement.
+			return new PrintStatement();
+		}
+
+		var printList = ProcessPrintList(reader, lineNumber);
+		return new PrintStatement(printList);
+	}
+
+	private static List<IPrintItem> ProcessPrintList(ComplexTokenReader reader, int? lineNumber = null)
+	{
+		var items = new List<IPrintItem>();
+
+		while (true)
+		{
+			var printItem = ProcessPrintItem(reader, lineNumber);
+			if (printItem != null)
 			{
-				return expr;
+				items.Add(printItem);
 			}
 
-			expr = ParseExpression(reader, lineNumber, false);
-			if (expr != null)
-			{
-				return expr;
-			}
+			ProcessSpace(reader, false);  // Optional space.
 
+			var printSeparator = ProcessPrintSeparator(reader);
+
+			ProcessSpace(reader, false);  // Optional space.
+
+			if (printSeparator == null)
+			{
+				// No separator, so this is the end of the list.
+				return items;
+			}
+			else
+			{
+				// If there's a separator, there might be another item.
+				items.Add(printSeparator);
+			}
+		}
+	}
+
+	private static IPrintItemSeparator? ProcessPrintSeparator(ComplexTokenReader reader)
+	{
+		var symbolToken = reader.Next(TokenType.Comma, false);
+		if (symbolToken != null)
+		{
+			return new CommaExpression();
+		}
+
+		symbolToken = reader.Next(TokenType.Semicolon, false);
+		if (symbolToken != null)
+		{
+			return new SemicolonExpression();
+		}
+
+		return null;
+	}
+
+	private static IPrintItem? ProcessPrintItem(ComplexTokenReader reader, int? lineNumber = null)
+	{
+		var expr = ProcessTabExpression(reader, lineNumber);
+		if (expr != null)
+		{
+			return expr;
+		}
+
+		expr = ParseExpression(reader, lineNumber, false);
+		if (expr != null)
+		{
+			return expr;
+		}
+
+		return null;
+	}
+
+	private static IPrintItem? ProcessTabExpression(ComplexTokenReader reader, int? lineNumber = null)
+	{
+		var token = reader.Next(TokenType.Word, false, "TAB");
+		if (token == null)
+		{
 			return null;
 		}
 
-		private static IPrintItem? ProcessTabExpression(ComplexTokenReader reader, int? lineNumber = null)
+		reader.Next(TokenType.OpenParenthesis);
+
+		var valueExpr = ParseNumericExpression(reader, lineNumber, true);
+		if (valueExpr == null)
 		{
-			var token = reader.Next(TokenType.Word, false, "TAB");
-			if (token == null)
-			{
-				return null;
-			}
-
-			reader.Next(TokenType.OpenParenthesis);
-
-			var valueExpr = ParseNumericExpression(reader, lineNumber, true);
-			if (valueExpr == null)
-			{
-				throw new Exceptions.SyntaxException("Expected numeric expression in TAB function", lineNumber);
-			}
-
-			reader.Next(TokenType.CloseParenthesis);
-
-			return new TabExpression(valueExpr);
+			throw new Exceptions.SyntaxException("Expected numeric expression in TAB function", lineNumber);
 		}
+
+		reader.Next(TokenType.CloseParenthesis);
+
+		return new TabExpression(valueExpr);
 	}
 }

--- a/src/ECMABasic.Core/Parsers/ReadStatementParser.cs
+++ b/src/ECMABasic.Core/Parsers/ReadStatementParser.cs
@@ -2,42 +2,41 @@
 using ECMABasic.Core.Statements;
 using System.Collections.Generic;
 
-namespace ECMABasic.Core.Parsers
+namespace ECMABasic.Core.Parsers;
+
+public class ReadStatementParser : StatementParser
 {
-	public class ReadStatementParser : StatementParser
+	public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
 	{
-		public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
+		var token = reader.Next(TokenType.Word, false, "READ");
+		if (token == null)
 		{
-			var token = reader.Next(TokenType.Word, false, "READ");
-			if (token == null)
-			{
-				return null;
-			}
-			ProcessSpace(reader, true);
-
-			var firstVar = ParseVariableExpression(reader);
-			if (firstVar == null)
-			{
-				throw new Exceptions.SyntaxException("Expected variable in READ statement", lineNumber);
-			}
-
-			var vars = new List<VariableExpression> { firstVar };
-
-			while (true)
-			{
-				if (reader.Next(TokenType.Comma, false) == null)
-				{
-					break;
-				}
-				ProcessSpace(reader, false);
-				var nextVar = ParseVariableExpression(reader);
-				if (nextVar != null)
-				{
-					vars.Add(nextVar);
-				}
-			}
-
-			return new ReadStatement(vars);
+			return null;
 		}
+		ProcessSpace(reader, true);
+
+		var firstVar = ParseVariableExpression(reader);
+		if (firstVar == null)
+		{
+			throw new Exceptions.SyntaxException("Expected variable in READ statement", lineNumber);
+		}
+
+		var vars = new List<VariableExpression> { firstVar };
+
+		while (true)
+		{
+			if (reader.Next(TokenType.Comma, false) == null)
+			{
+				break;
+			}
+			ProcessSpace(reader, false);
+			var nextVar = ParseVariableExpression(reader);
+			if (nextVar != null)
+			{
+				vars.Add(nextVar);
+			}
+		}
+
+		return new ReadStatement(vars);
 	}
 }

--- a/src/ECMABasic.Core/Parsers/RemarkStatementParser.cs
+++ b/src/ECMABasic.Core/Parsers/RemarkStatementParser.cs
@@ -1,36 +1,35 @@
 ﻿using ECMABasic.Core.Statements;
 using System.Text;
 
-namespace ECMABasic.Core.Parsers
+namespace ECMABasic.Core.Parsers;
+
+public class RemarkStatementParser : StatementParser
 {
-	public class RemarkStatementParser : StatementParser
+	public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
 	{
-		public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
+		var token = reader.Next(TokenType.Word, false, "REM");
+		if (token == null)
 		{
-			var token = reader.Next(TokenType.Word, false, "REM");
-			if (token == null)
-			{
-				return null;
-			}
-
-			if (ProcessSpace(reader, false) == null)
-			{
-				return new RemarkStatement(string.Empty);
-			}
-
-			var sb = new StringBuilder();
-			while (true)
-			{
-				if (reader.Peek()?.Type == TokenType.EndOfLine)
-				{
-					break;
-				}
-
-				// TODO: The tokenizer is getting choked up if it finds a double-quote in the text.
-				sb.Append(reader.Next()!.Text);
-			}
-
-			return new RemarkStatement(sb.ToString());
+			return null;
 		}
+
+		if (ProcessSpace(reader, false) == null)
+		{
+			return new RemarkStatement(string.Empty);
+		}
+
+		var sb = new StringBuilder();
+		while (true)
+		{
+			if (reader.Peek()?.Type == TokenType.EndOfLine)
+			{
+				break;
+			}
+
+			// TODO: The tokenizer is getting choked up if it finds a double-quote in the text.
+			sb.Append(reader.Next()!.Text);
+		}
+
+		return new RemarkStatement(sb.ToString());
 	}
 }

--- a/src/ECMABasic.Core/Parsers/RestoreStatementParser.cs
+++ b/src/ECMABasic.Core/Parsers/RestoreStatementParser.cs
@@ -1,17 +1,16 @@
 ﻿using ECMABasic.Core.Statements;
 
-namespace ECMABasic.Core.Parsers
+namespace ECMABasic.Core.Parsers;
+
+public class RestoreStatementParser : StatementParser
 {
-	public class RestoreStatementParser : StatementParser
+	public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
 	{
-		public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
+		var token = reader.Next(TokenType.Word, false, "RESTORE");
+		if (token == null)
 		{
-			var token = reader.Next(TokenType.Word, false, "RESTORE");
-			if (token == null)
-			{
-				return null;
-			}
-			return new RestoreStatement();
+			return null;
 		}
+		return new RestoreStatement();
 	}
 }

--- a/src/ECMABasic.Core/Parsers/ReturnStatementParser.cs
+++ b/src/ECMABasic.Core/Parsers/ReturnStatementParser.cs
@@ -1,17 +1,16 @@
 ﻿using ECMABasic.Core.Statements;
 
-namespace ECMABasic.Core.Parsers
+namespace ECMABasic.Core.Parsers;
+
+public class ReturnStatementParser : StatementParser
 {
-	public class ReturnStatementParser : StatementParser
+	public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
 	{
-		public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
+		var token = reader.Next(TokenType.Word, false, "RETURN");
+		if (token == null)
 		{
-			var token = reader.Next(TokenType.Word, false, "RETURN");
-			if (token == null)
-			{
-				return null;
-			}
-			return new ReturnStatement();
+			return null;
 		}
+		return new ReturnStatement();
 	}
 }

--- a/src/ECMABasic.Core/Parsers/StopStatementParser.cs
+++ b/src/ECMABasic.Core/Parsers/StopStatementParser.cs
@@ -1,17 +1,16 @@
 ﻿using ECMABasic.Core.Statements;
 
-namespace ECMABasic.Core
+namespace ECMABasic.Core;
+
+public class StopStatementParser : StatementParser
 {
-	public class StopStatementParser : StatementParser
+	public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
 	{
-		public override IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null)
+		var token = reader.Next(TokenType.Word, false, "STOP");
+		if (token == null)
 		{
-			var token = reader.Next(TokenType.Word, false, "STOP");
-			if (token == null)
-			{
-				return null;
-			}
-			return new StopStatement();
+			return null;
 		}
+		return new StopStatement();
 	}
 }

--- a/src/ECMABasic.Core/Program.cs
+++ b/src/ECMABasic.Core/Program.cs
@@ -4,223 +4,222 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace ECMABasic.Core
+namespace ECMABasic.Core;
+
+/// <summary>
+/// A program is an executable list of program lines.
+/// </summary>
+public class Program : IEnumerable<ProgramLine>, IListable
 {
+	private readonly Dictionary<int, ProgramLine> _lines = new();
+	private readonly List<ProgramLine> _sortedLines = new();
+	private readonly Dictionary<int, int> _lineNumberToIndex = new();
+
 	/// <summary>
-	/// A program is an executable list of program lines.
+	/// Maintain a list of line indices that contain DATA statements.
 	/// </summary>
-	public class Program : IEnumerable<ProgramLine>, IListable
+	private readonly List<int> _datas = new();
+
+	public ProgramLine? this[int lineNumber]
 	{
-		private readonly Dictionary<int, ProgramLine> _lines = new();
-		private readonly List<ProgramLine> _sortedLines = new();
-		private readonly Dictionary<int, int> _lineNumberToIndex = new();
-
-		/// <summary>
-		/// Maintain a list of line indices that contain DATA statements.
-		/// </summary>
-		private readonly List<int> _datas = new();
-
-		public ProgramLine? this[int lineNumber]
+		get
 		{
-			get
+			if (_lines.ContainsKey(lineNumber))
 			{
-				if (_lines.ContainsKey(lineNumber))
-				{
-					return _lines[lineNumber];
-				}
-				else
-				{
-					return null;
-				}
+				return _lines[lineNumber];
+			}
+			else
+			{
+				return null;
 			}
 		}
+	}
 
-		public int Length
+	public int Length
+	{
+		get
 		{
-			get
-			{
-				return _sortedLines.Count;
-			}
+			return _sortedLines.Count;
+		}
+	}
+
+	public void Execute(IEnvironment env)
+	{
+		if (Length == 0)
+		{
+			// Nothing to execute.
+			return;
 		}
 
-		public void Execute(IEnvironment env)
+		try
 		{
-			if (Length == 0)
+			ValidateEndLine();
+
+			// Begin executing with the first line number.
+			var lineIndex = 0;
+			if (env.CurrentLineNumber == 0)
 			{
-				// Nothing to execute.
-				return;
+				env.CurrentLineNumber = _sortedLines[lineIndex].LineNumber;
+			}
+			else
+			{
+				lineIndex = _lineNumberToIndex[env.CurrentLineNumber];
 			}
 
-			try
+			while (true)
 			{
-				ValidateEndLine();
+				env.CheckForStopRequest();
 
-				// Begin executing with the first line number.
-				var lineIndex = 0;
-				if (env.CurrentLineNumber == 0)
+				var oldLineNumber = env.CurrentLineNumber;
+				var line = this[env.CurrentLineNumber];
+				line!.Statement!.Execute(env, false);
+				if (oldLineNumber == env.CurrentLineNumber)
 				{
+					// The statement didn't modify the current line number, so we can simply move to the next one.
+					lineIndex++;
 					env.CurrentLineNumber = _sortedLines[lineIndex].LineNumber;
 				}
 				else
 				{
+					// The statement modified the current line number, so we need to recalculate the line index.
+					var nextLine = _lines[env.CurrentLineNumber];
 					lineIndex = _lineNumberToIndex[env.CurrentLineNumber];
 				}
 
-				while (true)
+				if (lineIndex >= Length)
 				{
-					env.CheckForStopRequest();
-
-					var oldLineNumber = env.CurrentLineNumber;
-					var line = this[env.CurrentLineNumber];
-					line!.Statement!.Execute(env, false);
-					if (oldLineNumber == env.CurrentLineNumber)
-					{
-						// The statement didn't modify the current line number, so we can simply move to the next one.
-						lineIndex++;
-						env.CurrentLineNumber = _sortedLines[lineIndex].LineNumber;
-					}
-					else
-					{
-						// The statement modified the current line number, so we need to recalculate the line index.
-						var nextLine = _lines[env.CurrentLineNumber];
-						lineIndex = _lineNumberToIndex[env.CurrentLineNumber];
-					}
-
-					if (lineIndex >= Length)
-					{
-						throw ExceptionFactory.ProgramEnd(env.CurrentLineNumber);
-					}
+					throw ExceptionFactory.ProgramEnd(env.CurrentLineNumber);
 				}
 			}
-			catch (ProgramEndException)
-			{
-			}
-			catch (RuntimeException ex)
-			{
-				env.ReportError(ex.Message);
-			}
-			catch (SyntaxException ex)
-			{
-				env.ReportError(ex.Message);
-			}
 		}
-
-		public int GetNextLineNumber(int fromLineNumber)
+		catch (ProgramEndException)
 		{
-			var lineIndex = _lineNumberToIndex[fromLineNumber];
-			lineIndex++;
-			if (lineIndex < Length)
-			{
-				return _sortedLines[lineIndex].LineNumber;
-			}
-			else
-			{
-				return -1;
-			}
 		}
-
-		public ProgramLine? MoveToNextLine(IEnvironment env)
+		catch (RuntimeException ex)
 		{
-			env.CurrentLineNumber = GetNextLineNumber(env.CurrentLineNumber);
-			return this[env.CurrentLineNumber];
+			env.ReportError(ex.Message);
 		}
-
-		public void Insert(ProgramLine line)
+		catch (SyntaxException ex)
 		{
-			_lines[line.LineNumber] = line;
+			env.ReportError(ex.Message);
+		}
+	}
+
+	public int GetNextLineNumber(int fromLineNumber)
+	{
+		var lineIndex = _lineNumberToIndex[fromLineNumber];
+		lineIndex++;
+		if (lineIndex < Length)
+		{
+			return _sortedLines[lineIndex].LineNumber;
+		}
+		else
+		{
+			return -1;
+		}
+	}
+
+	public ProgramLine? MoveToNextLine(IEnvironment env)
+	{
+		env.CurrentLineNumber = GetNextLineNumber(env.CurrentLineNumber);
+		return this[env.CurrentLineNumber];
+	}
+
+	public void Insert(ProgramLine line)
+	{
+		_lines[line.LineNumber] = line;
+		RebuildIndex();
+	}
+	
+	public void Delete(int lineNumber)
+	{
+		if (_lines.ContainsKey(lineNumber))
+		{
+			_lines.Remove(lineNumber);
 			RebuildIndex();
 		}
-		
-		public void Delete(int lineNumber)
+	}
+
+	/// <summary>
+	/// Retrieve a data line.
+	/// </summary>
+	/// <param name="n">The data index (which is not the line number).</param>
+	/// <returns>The DATA statement, or null if out of range.</returns>
+	/// <exception cref="RuntimeException">Thrown if the line number doesn't contain a DATA statement.</exception>
+	public DataStatement? GetDataLine(int n)
+	{
+		if (n >= _datas.Count)
 		{
-			if (_lines.ContainsKey(lineNumber))
-			{
-				_lines.Remove(lineNumber);
-				RebuildIndex();
-			}
+			return null;
 		}
 
-		/// <summary>
-		/// Retrieve a data line.
-		/// </summary>
-		/// <param name="n">The data index (which is not the line number).</param>
-		/// <returns>The DATA statement, or null if out of range.</returns>
-		/// <exception cref="RuntimeException">Thrown if the line number doesn't contain a DATA statement.</exception>
-		public DataStatement? GetDataLine(int n)
+		var line = _sortedLines[_datas[n]];
+		var stmt = line.Statement;
+		if (stmt is DataStatement)
 		{
-			if (n >= _datas.Count)
-			{
-				return null;
-			}
+			return stmt as DataStatement;
+		}
+		else
+		{
+			throw ExceptionFactory.ExpectedData(line.LineNumber);
+		}
+	}
 
-			var line = _sortedLines[_datas[n]];
-			var stmt = line.Statement;
-			if (stmt is DataStatement)
+	private void RebuildIndex()
+	{
+		_sortedLines.Clear();
+		_lineNumberToIndex.Clear();
+		_datas.Clear();
+
+		var n = 0;
+		foreach (var l in _lines.OrderBy(x => x.Value.LineNumber).Select(x => x.Value))
+		{
+			_sortedLines.Add(l);
+			_lineNumberToIndex[l.LineNumber] = n;
+			if (l.Statement is DataStatement)
 			{
-				return stmt as DataStatement;
+				_datas.Add(n);
 			}
-			else
-			{
-				throw ExceptionFactory.ExpectedData(line.LineNumber);
-			}
+			n++;
+		}
+	}
+
+	public void Clear()
+	{
+		_lines.Clear();
+		_sortedLines.Clear();
+	}
+
+	public string ToListing()
+	{
+		return string.Join(string.Empty, _lines.Select(x => x.Value.ToListing()));
+	}
+
+	public IEnumerator<ProgramLine> GetEnumerator()
+	{
+		foreach (var line in _sortedLines)
+		{
+			yield return line;
+		}
+	}
+
+	IEnumerator IEnumerable.GetEnumerator()
+	{
+		return GetEnumerator();
+	}
+
+	private void ValidateEndLine()
+	{
+		var ENDs = this.Where(x => x.Statement is EndStatement);
+		if (!ENDs.Any())
+		{
+			throw ExceptionFactory.NoEndInstruction();
 		}
 
-		private void RebuildIndex()
+		var lastLineNumber = this.Max(x => x.LineNumber);
+		if (ENDs.First().LineNumber != lastLineNumber)
 		{
-			_sortedLines.Clear();
-			_lineNumberToIndex.Clear();
-			_datas.Clear();
-
-			var n = 0;
-			foreach (var l in _lines.OrderBy(x => x.Value.LineNumber).Select(x => x.Value))
-			{
-				_sortedLines.Add(l);
-				_lineNumberToIndex[l.LineNumber] = n;
-				if (l.Statement is DataStatement)
-				{
-					_datas.Add(n);
-				}
-				n++;
-			}
-		}
-
-		public void Clear()
-		{
-			_lines.Clear();
-			_sortedLines.Clear();
-		}
-
-		public string ToListing()
-		{
-			return string.Join(string.Empty, _lines.Select(x => x.Value.ToListing()));
-		}
-
-		public IEnumerator<ProgramLine> GetEnumerator()
-		{
-			foreach (var line in _sortedLines)
-			{
-				yield return line;
-			}
-		}
-
-		IEnumerator IEnumerable.GetEnumerator()
-		{
-			return GetEnumerator();
-		}
-
-		private void ValidateEndLine()
-		{
-			var ENDs = this.Where(x => x.Statement is EndStatement);
-			if (!ENDs.Any())
-			{
-				throw ExceptionFactory.NoEndInstruction();
-			}
-
-			var lastLineNumber = this.Max(x => x.LineNumber);
-			if (ENDs.First().LineNumber != lastLineNumber)
-			{
-				throw ExceptionFactory.EndIsNotLast(ENDs.First().LineNumber);
-			}
+			throw ExceptionFactory.EndIsNotLast(ENDs.First().LineNumber);
 		}
 	}
 }

--- a/src/ECMABasic.Core/ProgramLine.cs
+++ b/src/ECMABasic.Core/ProgramLine.cs
@@ -1,43 +1,42 @@
 ﻿using System;
 
-namespace ECMABasic.Core
+namespace ECMABasic.Core;
+
+/// <summary>
+/// Represents a single line of a program.
+/// </summary>
+public class ProgramLine : IListable
 {
     /// <summary>
-    /// Represents a single line of a program.
+    /// Construct a program line instance.
     /// </summary>
-    public class ProgramLine : IListable
+    /// <param name="lineNumber">The line number.</param>
+    /// <param name="statement">The statement to execute on this line.</param>
+    /// <param name="parent">The parent FOR block, if any.</param>
+    public ProgramLine(int lineNumber, IStatement? statement, ProgramLine? parent)
     {
-        /// <summary>
-        /// Construct a program line instance.
-        /// </summary>
-        /// <param name="lineNumber">The line number.</param>
-        /// <param name="statement">The statement to execute on this line.</param>
-        /// <param name="parent">The parent FOR block, if any.</param>
-        public ProgramLine(int lineNumber, IStatement? statement, ProgramLine? parent)
-        {
-            LineNumber = lineNumber;
-            Statement = statement;
-            Parent = parent;
-        }
+        LineNumber = lineNumber;
+        Statement = statement;
+        Parent = parent;
+    }
 
-        /// <summary>
-        /// The line number.
-        /// </summary>
-        public int LineNumber { get; }
+    /// <summary>
+    /// The line number.
+    /// </summary>
+    public int LineNumber { get; }
 
-        /// <summary>
-        /// The statement to execute on this line.
-        /// </summary>
-        public IStatement? Statement { get; }
+    /// <summary>
+    /// The statement to execute on this line.
+    /// </summary>
+    public IStatement? Statement { get; }
 
-        /// <summary>
-        /// Is this line contained in a block?
-        /// </summary>
-        public ProgramLine? Parent { get; }
+    /// <summary>
+    /// Is this line contained in a block?
+    /// </summary>
+    public ProgramLine? Parent { get; }
 
-        public string ToListing()
-		{
-			return string.Concat(LineNumber.ToString(), " ", Statement?.ToListing(), Environment.NewLine);
-		}
+    public string ToListing()
+	{
+		return string.Concat(LineNumber.ToString(), " ", Statement?.ToListing(), Environment.NewLine);
 	}
 }

--- a/src/ECMABasic.Core/RandomFactory.cs
+++ b/src/ECMABasic.Core/RandomFactory.cs
@@ -4,99 +4,98 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace ECMABasic.Core
+namespace ECMABasic.Core;
+
+/// <summary>
+/// A centralized random number provider.
+/// </summary>
+public class RandomFactory
 {
-	/// <summary>
-	/// A centralized random number provider.
-	/// </summary>
-	public class RandomFactory
+	private Random _random = new();
+
+	static RandomFactory()
 	{
-		private Random _random = new();
+		Instance = new();
+	}
 
-		static RandomFactory()
-		{
-			Instance = new();
-		}
+	private RandomFactory()
+	{
+	}
 
-		private RandomFactory()
-		{
-		}
+	public static RandomFactory Instance { get; }
 
-		public static RandomFactory Instance { get; }
+	/// <summary>
+	/// Initializes a new instance of the System.Random class, using the specified seed value.
+	/// </summary>
+	/// <param name="seed">
+	/// A number used to calculate a starting value for the pseudo-random number sequence.
+	/// If a negative number is specified, the absolute value of the number is used.
+	/// </param>
+	public void Reseed(int seed)
+	{
+		_random = new Random(seed);
+	}
 
-		/// <summary>
-		/// Initializes a new instance of the System.Random class, using the specified seed value.
-		/// </summary>
-		/// <param name="seed">
-		/// A number used to calculate a starting value for the pseudo-random number sequence.
-		/// If a negative number is specified, the absolute value of the number is used.
-		/// </param>
-		public void Reseed(int seed)
-		{
-			_random = new Random(seed);
-		}
+	/// <summary>
+	/// Returns a non-negative random integer.
+	/// </summary>
+	/// <returns>
+	/// A 32-bit signed integer that is greater than or equal to 0 and less than System.Int32.MaxValue.
+	/// </returns>
+	public int Next()
+	{
+		return _random.Next();
+	}
 
-		/// <summary>
-		/// Returns a non-negative random integer.
-		/// </summary>
-		/// <returns>
-		/// A 32-bit signed integer that is greater than or equal to 0 and less than System.Int32.MaxValue.
-		/// </returns>
-		public int Next()
-		{
-			return _random.Next();
-		}
+	/// <summary>
+	/// Returns a non-negative random integer that is less than the specified maximum.
+	/// </summary>
+	/// <param name="maxValue">
+	/// The exclusive upper bound of the random number to be generated. maxValue must be greater than or equal to 0.
+	/// </param>
+	/// <returns>
+	/// A 32-bit signed integer that is greater than or equal to 0, and less than maxValue;
+	/// that is, the range of return values ordinarily includes 0 but not maxValue. However,
+	/// if maxValue equals 0, maxValue is returned.
+	/// </returns>
+	/// <exception cref="ArgumentOutOfRangeException">
+	/// <paramref name="maxValue"/> is less than 0.
+	/// </exception>
+	public int Next(int maxValue)
+	{
+		return _random.Next(maxValue);
+	}
 
-		/// <summary>
-		/// Returns a non-negative random integer that is less than the specified maximum.
-		/// </summary>
-		/// <param name="maxValue">
-		/// The exclusive upper bound of the random number to be generated. maxValue must be greater than or equal to 0.
-		/// </param>
-		/// <returns>
-		/// A 32-bit signed integer that is greater than or equal to 0, and less than maxValue;
-		/// that is, the range of return values ordinarily includes 0 but not maxValue. However,
-		/// if maxValue equals 0, maxValue is returned.
-		/// </returns>
-		/// <exception cref="ArgumentOutOfRangeException">
-		/// <paramref name="maxValue"/> is less than 0.
-		/// </exception>
-		public int Next(int maxValue)
-		{
-			return _random.Next(maxValue);
-		}
+	/// <summary>
+	/// Returns a random integer that is within a specified range.
+	/// </summary>
+	/// <param name="minValue">
+	/// The inclusive lower bound of the random number returned.
+	/// </param>
+	/// <param name="maxValue">
+	/// The exclusive upper bound of the random number returned. maxValue must be greater than or equal to minValue.
+	/// </param>
+	/// <returns>
+	/// A 32-bit signed integer greater than or equal to minValue and less than maxValue;
+	/// that is, the range of return values includes minValue but not maxValue. If minValue
+	/// equals maxValue, minValue is returned.
+	/// </returns>
+	/// <exception cref="ArgumentOutOfRangeException">
+	/// <paramref name="minValue"/> is greater than <paramref name="maxValue"/>.
+	/// </exception>
+	public int Next(int minValue, int maxValue)
+	{
+		return _random.Next(minValue, maxValue);
+	}
 
-		/// <summary>
-		/// Returns a random integer that is within a specified range.
-		/// </summary>
-		/// <param name="minValue">
-		/// The inclusive lower bound of the random number returned.
-		/// </param>
-		/// <param name="maxValue">
-		/// The exclusive upper bound of the random number returned. maxValue must be greater than or equal to minValue.
-		/// </param>
-		/// <returns>
-		/// A 32-bit signed integer greater than or equal to minValue and less than maxValue;
-		/// that is, the range of return values includes minValue but not maxValue. If minValue
-		/// equals maxValue, minValue is returned.
-		/// </returns>
-		/// <exception cref="ArgumentOutOfRangeException">
-		/// <paramref name="minValue"/> is greater than <paramref name="maxValue"/>.
-		/// </exception>
-		public int Next(int minValue, int maxValue)
-		{
-			return _random.Next(minValue, maxValue);
-		}
-
-		/// <summary>
-		/// Returns a random floating-point number that is greater than or equal to 0.0, and less than 1.0.
-		/// </summary>
-		/// <returns>
-		/// A double-precision floating point number that is greater than or equal to 0.0, and less than 1.0.
-		/// </returns>
-		public double NextDouble()
-		{
-			return _random.NextDouble();
-		}
+	/// <summary>
+	/// Returns a random floating-point number that is greater than or equal to 0.0, and less than 1.0.
+	/// </summary>
+	/// <returns>
+	/// A double-precision floating point number that is greater than or equal to 0.0, and less than 1.0.
+	/// </returns>
+	public double NextDouble()
+	{
+		return _random.NextDouble();
 	}
 }

--- a/src/ECMABasic.Core/SimpleTokenReader.cs
+++ b/src/ECMABasic.Core/SimpleTokenReader.cs
@@ -3,101 +3,100 @@ using System;
 using System.IO;
 using System.Text;
 
-namespace ECMABasic.Core
+namespace ECMABasic.Core;
+
+/// <summary>
+/// Performance a simple processing of text into basic token classes.
+/// </summary>
+/// <remarks>
+/// Complex tokens, like negative floating-point numbers, will be handled later in the process.
+/// </remarks>
+public class SimpleTokenReader : IDisposable
 {
-    /// <summary>
-    /// Performance a simple processing of text into basic token classes.
-    /// </summary>
-    /// <remarks>
-    /// Complex tokens, like negative floating-point numbers, will be handled later in the process.
-    /// </remarks>
-    public class SimpleTokenReader : IDisposable
+    private readonly Stream _stream;
+    private readonly CharacterReader _reader;
+    private bool _disposedValue;
+
+    private SimpleTokenReader(Stream stream)
     {
-        private readonly Stream _stream;
-        private readonly CharacterReader _reader;
-        private bool _disposedValue;
+        _stream = stream;
+        _reader = new CharacterReader(stream);
+    }
 
-        private SimpleTokenReader(Stream stream)
+    public bool IsAtEnd => _reader.IsAtEnd;
+
+    public static SimpleTokenReader FromFile(string filename)
+    {
+        return new SimpleTokenReader(new FileStream(filename, FileMode.Open, FileAccess.Read));
+    }
+    
+    public static SimpleTokenReader FromText(string text)
+    {
+        return new SimpleTokenReader(new MemoryStream(Encoding.ASCII.GetBytes(text)));
+    }
+
+    /// <summary>
+    /// Pull the next token off of the stream.
+    /// </summary>
+    /// <returns>The token that was read, or null at the end of the stream.</returns>
+    public Token? Next()
+    {
+        if (IsAtEnd)
         {
-            _stream = stream;
-            _reader = new CharacterReader(stream);
+            return null;
         }
 
-        public bool IsAtEnd => _reader.IsAtEnd;
-
-        public static SimpleTokenReader FromFile(string filename)
+        var line = _reader.LineNumber;
+        var column = _reader.ColumnNumber;
+        var ch = _reader.Peek();
+        if (CharacterReader.IsDigit(ch))
         {
-            return new SimpleTokenReader(new FileStream(filename, FileMode.Open, FileAccess.Read));
+            var text = _reader.ReadInteger();
+            return new Token(TokenType.Integer, line, column, text);
         }
-        
-        public static SimpleTokenReader FromText(string text)
+        else if (CharacterReader.IsLetter(ch))
         {
-            return new SimpleTokenReader(new MemoryStream(Encoding.ASCII.GetBytes(text)));
+            var text = _reader.ReadWord();
+            return new Token(TokenType.Word, line, column, text);
         }
-
-        /// <summary>
-        /// Pull the next token off of the stream.
-        /// </summary>
-        /// <returns>The token that was read, or null at the end of the stream.</returns>
-        public Token? Next()
+        else if (CharacterReader.IsSymbol(ch))
         {
-            if (IsAtEnd)
-            {
-                return null;
-            }
-
-            var line = _reader.LineNumber;
-            var column = _reader.ColumnNumber;
-            var ch = _reader.Peek();
-            if (CharacterReader.IsDigit(ch))
-            {
-                var text = _reader.ReadInteger();
-                return new Token(TokenType.Integer, line, column, text);
-            }
-            else if (CharacterReader.IsLetter(ch))
-            {
-                var text = _reader.ReadWord();
-                return new Token(TokenType.Word, line, column, text);
-            }
-            else if (CharacterReader.IsSymbol(ch))
-            {
-                var text = _reader.ReadSymbol();
-                return new Token(TokenType.Symbol, line, column, text);
-            }
-            else if (CharacterReader.IsSpace(ch))
-            {
-                var text = _reader.ReadSpace();
-                return new Token(TokenType.Space, line, column, text);
-            }
-            else if (CharacterReader.IsEndOfLine(ch))
-			{
-                var text = _reader.ReadEndOfLine();
-                return new Token(TokenType.EndOfLine, line, column, text);
-			}
-
-            throw new UnexpectedCharacterException(line, column, "integer|word|symbol|space", ch);
+            var text = _reader.ReadSymbol();
+            return new Token(TokenType.Symbol, line, column, text);
         }
-
-        protected virtual void Dispose(bool disposing)
+        else if (CharacterReader.IsSpace(ch))
         {
-            if (!_disposedValue)
-            {
-                if (disposing)
-                {
-                    _reader.Dispose();
-                    _stream.Close();
-                    _stream.Dispose();
-                }
-
-                _disposedValue = true;
-            }
+            var text = _reader.ReadSpace();
+            return new Token(TokenType.Space, line, column, text);
         }
+        else if (CharacterReader.IsEndOfLine(ch))
+		{
+            var text = _reader.ReadEndOfLine();
+            return new Token(TokenType.EndOfLine, line, column, text);
+		}
 
-        public void Dispose()
+        throw new UnexpectedCharacterException(line, column, "integer|word|symbol|space", ch);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposedValue)
         {
-            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-            Dispose(disposing: true);
-            GC.SuppressFinalize(this);
+            if (disposing)
+            {
+                _reader.Dispose();
+                _stream.Close();
+                _stream.Dispose();
+            }
+
+            _disposedValue = true;
         }
+    }
+
+    public void Dispose()
+    {
+        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/ECMABasic.Core/StatementParser.cs
+++ b/src/ECMABasic.Core/StatementParser.cs
@@ -1,86 +1,85 @@
 ﻿using ECMABasic.Core.Exceptions;
 using ECMABasic.Core.Expressions;
 
-namespace ECMABasic.Core
+namespace ECMABasic.Core;
+
+public abstract class StatementParser
 {
-	public abstract class StatementParser
+	/// <summary>
+	/// Parse a statement off of the next series of tokens.
+	/// </summary>
+	/// <param name="reader"></param>
+	/// <param name="lineNumber">The current line number.  Null for immediate evaluation.</param>
+	/// <returns>The executable statement, or null if parsing fails.</returns>
+	public abstract IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null);
+
+	/// <summary>
+	/// Read whitespace off of the token stream.
+	/// An exception will optionally occur if whitespace could not be found.
+	/// </summary>
+	/// <param name="reader">The token reader.</param>
+	/// <param name="throwOnError">Throw an exception if space is not found.  Default to true.</param>
+	/// <returns>The space token, or null if not found and throwOnError is false.</returns>
+	protected static Token? ProcessSpace(ComplexTokenReader reader, bool throwOnError = true)
 	{
-		/// <summary>
-		/// Parse a statement off of the next series of tokens.
-		/// </summary>
-		/// <param name="reader"></param>
-		/// <param name="lineNumber">The current line number.  Null for immediate evaluation.</param>
-		/// <returns>The executable statement, or null if parsing fails.</returns>
-		public abstract IStatement? Parse(ComplexTokenReader reader, int? lineNumber = null);
+		return reader.Next(TokenType.Space, throwOnError);
+	}
 
-		/// <summary>
-		/// Read whitespace off of the token stream.
-		/// An exception will optionally occur if whitespace could not be found.
-		/// </summary>
-		/// <param name="reader">The token reader.</param>
-		/// <param name="throwOnError">Throw an exception if space is not found.  Default to true.</param>
-		/// <returns>The space token, or null if not found and throwOnError is false.</returns>
-		protected static Token? ProcessSpace(ComplexTokenReader reader, bool throwOnError = true)
+	protected static IExpression? ParseExpression(ComplexTokenReader reader, int? lineNumber, bool throwOnError)
+	{
+		return ParseBinaryExpression(reader, lineNumber, throwOnError);
+	}
+
+	protected static IExpression? ParseBinaryExpression(ComplexTokenReader reader, int? lineNumber, bool throwOnError)
+	{
+		var expr = new StringExpressionParser(reader, lineNumber, throwOnError).Parse();
+		if (expr == null)
 		{
-			return reader.Next(TokenType.Space, throwOnError);
+			expr = new NumericExpressionParser(reader, lineNumber, throwOnError).Parse();
+		}
+		return expr;
+	}
+
+	protected static IExpression? ParseAtomicExpression(ComplexTokenReader reader, int? lineNumber, bool throwOnError)
+	{
+		var valueExpr = ParseNumericExpression(reader, lineNumber, false);
+		if (valueExpr != null)
+		{
+			return valueExpr;
 		}
 
-		protected static IExpression? ParseExpression(ComplexTokenReader reader, int? lineNumber, bool throwOnError)
+		valueExpr = ParseStringExpression(reader, lineNumber, throwOnError);
+		if (valueExpr != null)
 		{
-			return ParseBinaryExpression(reader, lineNumber, throwOnError);
+			return valueExpr;
 		}
 
-		protected static IExpression? ParseBinaryExpression(ComplexTokenReader reader, int? lineNumber, bool throwOnError)
+		return null;
+	}
+
+	/// <summary>
+	/// This will parse either a numeric variable or a string variable.
+	/// </summary>
+	/// <param name="reader">The tokenizer to pull the variable text from.</param>
+	/// <returns>The variable expression, or null if no valid variable found.</returns>
+	protected static VariableExpression? ParseVariableExpression(ComplexTokenReader reader)
+	{
+		var nameToken = reader.Next(TokenType.Word, false, @"[A-Z][\$\d]?");
+		if (nameToken == null)
 		{
-			var expr = new StringExpressionParser(reader, lineNumber, throwOnError).Parse();
-			if (expr == null)
-			{
-				expr = new NumericExpressionParser(reader, lineNumber, throwOnError).Parse();
-			}
-			return expr;
-		}
-
-		protected static IExpression? ParseAtomicExpression(ComplexTokenReader reader, int? lineNumber, bool throwOnError)
-		{
-			var valueExpr = ParseNumericExpression(reader, lineNumber, false);
-			if (valueExpr != null)
-			{
-				return valueExpr;
-			}
-
-			valueExpr = ParseStringExpression(reader, lineNumber, throwOnError);
-			if (valueExpr != null)
-			{
-				return valueExpr;
-			}
-
 			return null;
 		}
 
-		/// <summary>
-		/// This will parse either a numeric variable or a string variable.
-		/// </summary>
-		/// <param name="reader">The tokenizer to pull the variable text from.</param>
-		/// <returns>The variable expression, or null if no valid variable found.</returns>
-		protected static VariableExpression? ParseVariableExpression(ComplexTokenReader reader)
-		{
-			var nameToken = reader.Next(TokenType.Word, false, @"[A-Z][\$\d]?");
-			if (nameToken == null)
-			{
-				return null;
-			}
+		return new VariableExpression(nameToken.Text);
+	}
 
-			return new VariableExpression(nameToken.Text);
-		}
+	protected static IExpression? ParseNumericExpression(ComplexTokenReader reader, int? lineNumber, bool throwOnError)
+	{
+		return new NumericExpressionParser(reader, lineNumber, throwOnError).Parse();
+	}
 
-		protected static IExpression? ParseNumericExpression(ComplexTokenReader reader, int? lineNumber, bool throwOnError)
-		{
-			return new NumericExpressionParser(reader, lineNumber, throwOnError).Parse();
-		}
-
-		protected static IExpression? ParseStringExpression(ComplexTokenReader reader, int? lineNumber, bool throwOnError)
-		{
-			return new StringExpressionParser(reader, lineNumber, throwOnError).Parse();
-		}
+	protected static IExpression? ParseStringExpression(ComplexTokenReader reader, int? lineNumber, bool throwOnError)
+	{
+		return new StringExpressionParser(reader, lineNumber, throwOnError).Parse();
 	}
 }

--- a/src/ECMABasic.Core/Statements/DataStatement.cs
+++ b/src/ECMABasic.Core/Statements/DataStatement.cs
@@ -2,33 +2,32 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace ECMABasic.Core.Statements
+namespace ECMABasic.Core.Statements;
+
+public class DataStatement : IStatement
 {
-	public class DataStatement : IStatement
+	public DataStatement(IEnumerable<IExpression> datums)
 	{
-		public DataStatement(IEnumerable<IExpression> datums)
+		if (!datums.All(x => x.IsReducible))
 		{
-			if (!datums.All(x => x.IsReducible))
-			{
-				throw new SyntaxException("DATUMS MUST BE REDUCIBLE TO STRING OR NUMERIC CONSTANTS");
-			}
-
-			Datums = new List<IExpression>(datums);
+			throw new SyntaxException("DATUMS MUST BE REDUCIBLE TO STRING OR NUMERIC CONSTANTS");
 		}
 
-		public List<IExpression> Datums { get; }
+		Datums = new List<IExpression>(datums);
+	}
 
-		public void Execute(IEnvironment env, bool isImmediate)
-		{
-			if (isImmediate)
-			{
-				throw ExceptionFactory.OnlyAllowedInProgram();
-			}
-		}
+	public List<IExpression> Datums { get; }
 
-		public string ToListing()
+	public void Execute(IEnvironment env, bool isImmediate)
+	{
+		if (isImmediate)
 		{
-			return string.Concat("DATA ", string.Join(",", Datums.Select(x => x.ToListing())));
+			throw ExceptionFactory.OnlyAllowedInProgram();
 		}
+	}
+
+	public string ToListing()
+	{
+		return string.Concat("DATA ", string.Join(",", Datums.Select(x => x.ToListing())));
 	}
 }

--- a/src/ECMABasic.Core/Statements/EndStatement.cs
+++ b/src/ECMABasic.Core/Statements/EndStatement.cs
@@ -1,21 +1,20 @@
 ﻿using ECMABasic.Core.Exceptions;
 
-namespace ECMABasic.Core.Statements
-{
-	public class EndStatement : IStatement
-	{
-		public void Execute(IEnvironment env, bool isImmediate)
-		{
-			if (isImmediate)
-			{
-				throw ExceptionFactory.OnlyAllowedInProgram();
-			}
-			throw ExceptionFactory.ProgramEnd(env.CurrentLineNumber);
-		}
+namespace ECMABasic.Core.Statements;
 
-		public string ToListing()
+public class EndStatement : IStatement
+{
+	public void Execute(IEnvironment env, bool isImmediate)
+	{
+		if (isImmediate)
 		{
-			return "END";
+			throw ExceptionFactory.OnlyAllowedInProgram();
 		}
+		throw ExceptionFactory.ProgramEnd(env.CurrentLineNumber);
+	}
+
+	public string ToListing()
+	{
+		return "END";
 	}
 }

--- a/src/ECMABasic.Core/Statements/ForStatement.cs
+++ b/src/ECMABasic.Core/Statements/ForStatement.cs
@@ -3,113 +3,112 @@ using ECMABasic.Core.Expressions;
 using System;
 using System.Collections.Generic;
 
-namespace ECMABasic.Core.Statements
+namespace ECMABasic.Core.Statements;
+
+public class ForStatement : IStatement
 {
-	public class ForStatement : IStatement
+	public ForStatement(VariableExpression loopVar, IExpression from, IExpression to, IExpression step)
 	{
-		public ForStatement(VariableExpression loopVar, IExpression from, IExpression to, IExpression step)
+		if (!loopVar.IsNumeric)
 		{
-			if (!loopVar.IsNumeric)
-			{
-				throw ExceptionFactory.ExpectedNumericVariable();
-			}
-			LoopVar = loopVar;
-			From = from;
-			To = to;
-			Step = step;
+			throw ExceptionFactory.ExpectedNumericVariable();
+		}
+		LoopVar = loopVar;
+		From = from;
+		To = to;
+		Step = step;
+	}
+
+	public VariableExpression LoopVar { get; }
+	public IExpression From { get; }
+	public IExpression To { get;}
+	public IExpression Step { get; }
+
+	public void Execute(IEnvironment env, bool isImmediate)
+	{
+		if (isImmediate)
+		{
+			throw ExceptionFactory.OnlyAllowedInProgram();
 		}
 
-		public VariableExpression LoopVar { get; }
-		public IExpression From { get; }
-		public IExpression To { get;}
-		public IExpression Step { get; }
+		var context = env.PopCallStack();
 
-		public void Execute(IEnvironment env, bool isImmediate)
+		if ((context is not ForStackContext forContext) || (forContext?.LoopVar?.Name != LoopVar.Name))
 		{
-			if (isImmediate)
+			// Either there's no FOR-context, or it's the wrong FOR-context.
+			if (context != null)
 			{
-				throw ExceptionFactory.OnlyAllowedInProgram();
+				// It's not ours, so put it back.
+				env.PushCallStack(context);
 			}
 
-			var context = env.PopCallStack();
+			// Null it out so we know to make a new one.
+			forContext = null!;
+		}
 
-			if ((context is not ForStackContext forContext) || (forContext?.LoopVar?.Name != LoopVar.Name))
+		if (forContext == null)
+		{
+			// This is the first time, so we need to build the context.
+			var from = Convert.ToDouble(From.Evaluate(env));
+			var to = Convert.ToDouble(To.Evaluate(env));
+			var step = Convert.ToDouble(Step.Evaluate(env));
+			env.SetNumericVariableValue(LoopVar.Name, from);
+
+			// Come back here when the loop is done (NEXT) to reevaluate the exit parameters.
+			var returnToLineNumber = env.CurrentLineNumber; // env.Program.GetNextLineNumber(env.CurrentLineNumber);
+			forContext = new ForStackContext(LoopVar, to, step, returnToLineNumber);
+		}
+		else
+		{
+			if (forContext?.LoopVar?.Name == LoopVar.Name)
 			{
-				// Either there's no FOR-context, or it's the wrong FOR-context.
-				if (context != null)
-				{
-					// It's not ours, so put it back.
-					env.PushCallStack(context);
-				}
-
-				// Null it out so we know to make a new one.
-				forContext = null!;
-			}
-
-			if (forContext == null)
-			{
-				// This is the first time, so we need to build the context.
-				var from = Convert.ToDouble(From.Evaluate(env));
-				var to = Convert.ToDouble(To.Evaluate(env));
-				var step = Convert.ToDouble(Step.Evaluate(env));
-				env.SetNumericVariableValue(LoopVar.Name, from);
-
-				// Come back here when the loop is done (NEXT) to reevaluate the exit parameters.
-				var returnToLineNumber = env.CurrentLineNumber; // env.Program.GetNextLineNumber(env.CurrentLineNumber);
-				forContext = new ForStackContext(LoopVar, to, step, returnToLineNumber);
+				// After the first time through the loop, we increment the control variable.
+				env.SetNumericVariableValue(LoopVar.Name, Convert.ToDouble(LoopVar.Evaluate(env)) + forContext.Step);
 			}
 			else
 			{
-				if (forContext?.LoopVar?.Name == LoopVar.Name)
-				{
-					// After the first time through the loop, we increment the control variable.
-					env.SetNumericVariableValue(LoopVar.Name, Convert.ToDouble(LoopVar.Evaluate(env)) + forContext.Step);
-				}
-				else
-				{
-					throw new InvalidOperationException();
-				}
+				throw new InvalidOperationException();
 			}
+		}
 
-			// We've already been through this loop once.
-			var own1 = forContext.To;
-			var own2 = forContext.Step;
-			var v = Convert.ToDouble(LoopVar.Evaluate(env));
+		// We've already been through this loop once.
+		var own1 = forContext.To;
+		var own2 = forContext.Step;
+		var v = Convert.ToDouble(LoopVar.Evaluate(env));
 
-			if ((v - own1) * Math.Sign(own2) > 0)
+		if ((v - own1) * Math.Sign(own2) > 0)
+		{
+			// Leave the for-block.
+
+			// Either get the block end line number, or search for it.
+			if (forContext.BlockEndLineNumber.HasValue)
 			{
-				// Leave the for-block.
-
-				// Either get the block end line number, or search for it.
-				if (forContext.BlockEndLineNumber.HasValue)
-				{
-					env.CurrentLineNumber = forContext.BlockEndLineNumber.Value;
-				}
-				else
-				{
-					// Scan for NEXT.
-					while (!(env.Program.MoveToNextLine(env)?.Statement is NextStatement))
-					{
-						;  // Continue scanning until NEXT found
-					}
-					// It'll stop incrementing when the NEXT is found.
-
-					// Move to the line *just after* the NEXT to continue running.
-					env.Program.MoveToNextLine(env);
-				}
+				env.CurrentLineNumber = forContext.BlockEndLineNumber.Value;
 			}
 			else
 			{
-				// We should be able to just enter the loop.
+				// Scan for NEXT.
+				while (!(env.Program.MoveToNextLine(env)?.Statement is NextStatement))
+				{
+					;  // Continue scanning until NEXT found
+				}
+				// It'll stop incrementing when the NEXT is found.
 
-				// Push the call stack so we're ready to do this again.
-				env.PushCallStack(forContext);
+				// Move to the line *just after* the NEXT to continue running.
+				env.Program.MoveToNextLine(env);
 			}
 		}
-
-		public string ToListing()
+		else
 		{
-			return string.Concat("FOR ", LoopVar.ToListing(), "=", From.ToListing(), " TO ", To.ToListing(), " STEP ", Step.ToListing());
+			// We should be able to just enter the loop.
+
+			// Push the call stack so we're ready to do this again.
+			env.PushCallStack(forContext);
 		}
+	}
+
+	public string ToListing()
+	{
+		return string.Concat("FOR ", LoopVar.ToListing(), "=", From.ToListing(), " TO ", To.ToListing(), " STEP ", Step.ToListing());
 	}
 }

--- a/src/ECMABasic.Core/Statements/GosubStatement.cs
+++ b/src/ECMABasic.Core/Statements/GosubStatement.cs
@@ -1,38 +1,37 @@
 ﻿using ECMABasic.Core.Exceptions;
 using System;
 
-namespace ECMABasic.Core.Statements
+namespace ECMABasic.Core.Statements;
+
+internal class GosubStatement : IStatement
 {
-	internal class GosubStatement : IStatement
+	public GosubStatement(IExpression lineNumber)
 	{
-		public GosubStatement(IExpression lineNumber)
+		LineNumber = lineNumber;
+	}
+
+	public IExpression LineNumber { get; }
+
+	public void Execute(IEnvironment env, bool isImmediate)
+	{
+		if (isImmediate)
 		{
-			LineNumber = lineNumber;
+			throw ExceptionFactory.OnlyAllowedInProgram();
 		}
 
-		public IExpression LineNumber { get; }
-
-		public void Execute(IEnvironment env, bool isImmediate)
+		var lineNumber = Convert.ToInt32(LineNumber.Evaluate(env));
+		if (!env.ValidateLineNumber(lineNumber, false))
 		{
-			if (isImmediate)
-			{
-				throw ExceptionFactory.OnlyAllowedInProgram();
-			}
-
-			var lineNumber = Convert.ToInt32(LineNumber.Evaluate(env));
-			if (!env.ValidateLineNumber(lineNumber, false))
-			{
-				throw ExceptionFactory.UndefinedLineNumber(lineNumber, env.CurrentLineNumber);
-			}
-
-			var returnToLineNumber = env.Program.GetNextLineNumber(env.CurrentLineNumber);
-			env.PushCallStack(new GosubStackContext(returnToLineNumber));
-			env.CurrentLineNumber = lineNumber;
+			throw ExceptionFactory.UndefinedLineNumber(lineNumber, env.CurrentLineNumber);
 		}
 
-		public string ToListing()
-		{
-			return string.Concat("GOSUB ", LineNumber.ToListing());
-		}
+		var returnToLineNumber = env.Program.GetNextLineNumber(env.CurrentLineNumber);
+		env.PushCallStack(new GosubStackContext(returnToLineNumber));
+		env.CurrentLineNumber = lineNumber;
+	}
+
+	public string ToListing()
+	{
+		return string.Concat("GOSUB ", LineNumber.ToListing());
 	}
 }

--- a/src/ECMABasic.Core/Statements/GotoStatement.cs
+++ b/src/ECMABasic.Core/Statements/GotoStatement.cs
@@ -1,96 +1,95 @@
 ﻿using System;
 
-namespace ECMABasic.Core.Statements
+namespace ECMABasic.Core.Statements;
+
+// TODO: # GOTO # needs to start an infinite loop.
+
+public class GotoStatement : IStatement
 {
-	// TODO: # GOTO # needs to start an infinite loop.
-
-	public class GotoStatement : IStatement
+	public GotoStatement(IExpression lineNumber)
 	{
-		public GotoStatement(IExpression lineNumber)
+		if (lineNumber.Type != ExpressionType.Number)
 		{
-			if (lineNumber.Type != ExpressionType.Number)
-			{
-				throw ExceptionFactory.ExpectedNumericExpression();
-			}
-			LineNumber = lineNumber;
+			throw ExceptionFactory.ExpectedNumericExpression();
+		}
+		LineNumber = lineNumber;
+	}
+
+	public IExpression LineNumber { get; }
+
+	/// <summary>
+	/// The <paramref name="src"/> parent tree needs to contain the parent of <paramref name="dst"/>.
+	/// </summary>
+	/// <param name="env">The execution environment.</param>
+	/// <param name="src">The line jumping from.</param>
+	/// <param name="dst">The line jumping to.</param>
+	private void ValidateSharedAncestry(IEnvironment env, ProgramLine? src, ProgramLine dst)
+	{
+		if (dst.Parent == null)
+		{
+			return;
 		}
 
-		public IExpression LineNumber { get; }
-
-		/// <summary>
-		/// The <paramref name="src"/> parent tree needs to contain the parent of <paramref name="dst"/>.
-		/// </summary>
-		/// <param name="env">The execution environment.</param>
-		/// <param name="src">The line jumping from.</param>
-		/// <param name="dst">The line jumping to.</param>
-		private void ValidateSharedAncestry(IEnvironment env, ProgramLine? src, ProgramLine dst)
+		if (src == null)
 		{
-			if (dst.Parent == null)
-			{
-				return;
-			}
-
-			if (src == null)
-			{
-				// We travelled all the way up without finding dst.Parent.
-				throw ExceptionFactory.ControlTransferIntoForBlock(env.CurrentLineNumber);
-			}
-
-			if (src.Parent == dst.Parent)
-			{
-				return;
-			}
-
-			ValidateSharedAncestry(env, src.Parent, dst);
+			// We travelled all the way up without finding dst.Parent.
+			throw ExceptionFactory.ControlTransferIntoForBlock(env.CurrentLineNumber);
 		}
 
-		public virtual void Execute(IEnvironment env, bool isImmediate)
+		if (src.Parent == dst.Parent)
 		{
-			if (isImmediate)
-			{
-				throw ExceptionFactory.OnlyAllowedInProgram();
-			}
+			return;
+		}
 
-			var thisLine = env.Program[env.CurrentLineNumber];
+		ValidateSharedAncestry(env, src.Parent, dst);
+	}
 
-			var lineNumber = Convert.ToInt32(LineNumber.Evaluate(env));
-			if (!env.ValidateLineNumber(lineNumber, false))
-			{
-				throw ExceptionFactory.UndefinedLineNumber(lineNumber, env.CurrentLineNumber);
-			}
+	public virtual void Execute(IEnvironment env, bool isImmediate)
+	{
+		if (isImmediate)
+		{
+			throw ExceptionFactory.OnlyAllowedInProgram();
+		}
 
-			var newLine = env.Program[lineNumber];
-			if (newLine != null)
-			{
-				ValidateSharedAncestry(env, thisLine, newLine);
-			}
-			env.CurrentLineNumber = lineNumber;
+		var thisLine = env.Program[env.CurrentLineNumber];
 
-			var context = env.PopCallStack();
-			if (context is ForStackContext)
+		var lineNumber = Convert.ToInt32(LineNumber.Evaluate(env));
+		if (!env.ValidateLineNumber(lineNumber, false))
+		{
+			throw ExceptionFactory.UndefinedLineNumber(lineNumber, env.CurrentLineNumber);
+		}
+
+		var newLine = env.Program[lineNumber];
+		if (newLine != null)
+		{
+			ValidateSharedAncestry(env, thisLine, newLine);
+		}
+		env.CurrentLineNumber = lineNumber;
+
+		var context = env.PopCallStack();
+		if (context is ForStackContext)
+		{
+			var forContext = (context as ForStackContext)!;
+			if ((env.CurrentLineNumber < forContext.BlockStartLineNumber) || (env.CurrentLineNumber >= forContext.BlockEndLineNumber))
 			{
-				var forContext = (context as ForStackContext)!;
-				if ((env.CurrentLineNumber < forContext.BlockStartLineNumber) || (env.CurrentLineNumber >= forContext.BlockEndLineNumber))
-				{
-					// We just jumped out of the FOR-block, so we can dispose of the context.
-				}
-				else
-				{
-					env.PushCallStack(context);
-				}
+				// We just jumped out of the FOR-block, so we can dispose of the context.
 			}
 			else
 			{
-				if (context != null)
-				{
-					env.PushCallStack(context);
-				}
+				env.PushCallStack(context);
 			}
 		}
-
-		public virtual string ToListing()
+		else
 		{
-			return string.Concat("GOTO ", LineNumber.ToListing());
+			if (context != null)
+			{
+				env.PushCallStack(context);
+			}
 		}
+	}
+
+	public virtual string ToListing()
+	{
+		return string.Concat("GOTO ", LineNumber.ToListing());
 	}
 }

--- a/src/ECMABasic.Core/Statements/IfThenStatement.cs
+++ b/src/ECMABasic.Core/Statements/IfThenStatement.cs
@@ -1,29 +1,28 @@
 ﻿using System;
 
-namespace ECMABasic.Core.Statements
+namespace ECMABasic.Core.Statements;
+
+public class IfThenStatement : GotoStatement
 {
-	public class IfThenStatement : GotoStatement
+	public IfThenStatement(IExpression condition, IExpression lineNumber)
+		: base(lineNumber)
 	{
-		public IfThenStatement(IExpression condition, IExpression lineNumber)
-			: base(lineNumber)
-		{
-			Condition = condition;
-		}
+		Condition = condition;
+	}
 
-		public IExpression Condition { get; }
+	public IExpression Condition { get; }
 
-		public override void Execute(IEnvironment env, bool isImmediate)
+	public override void Execute(IEnvironment env, bool isImmediate)
+	{
+		var condition = Convert.ToBoolean(Condition.Evaluate(env));
+		if (condition)
 		{
-			var condition = Convert.ToBoolean(Condition.Evaluate(env));
-			if (condition)
-			{
-				base.Execute(env, isImmediate);
-			}
+			base.Execute(env, isImmediate);
 		}
+	}
 
-		public override string ToListing()
-		{
-			return string.Concat("IF ", Condition.ToListing(), " THEN ", LineNumber.ToListing());
-		}
+	public override string ToListing()
+	{
+		return string.Concat("IF ", Condition.ToListing(), " THEN ", LineNumber.ToListing());
 	}
 }

--- a/src/ECMABasic.Core/Statements/InputStatement.cs
+++ b/src/ECMABasic.Core/Statements/InputStatement.cs
@@ -4,72 +4,71 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace ECMABasic.Core.Statements
+namespace ECMABasic.Core.Statements;
+
+public class InputStatement : IStatement
 {
-	public class InputStatement : IStatement
+	public InputStatement(IEnumerable<VariableExpression> variables)
 	{
-		public InputStatement(IEnumerable<VariableExpression> variables)
+		Variables = new List<VariableExpression>(variables);
+	}
+
+	public List<VariableExpression> Variables { get; }
+
+	public void Execute(IEnvironment env, bool isImmediate)
+	{
+		env.Print("? ");
+		var reply = env.ReadLine();
+
+		var reader = ComplexTokenReader.FromText(reply);
+
+		var isFirst = true;
+		foreach (var v in Variables)
 		{
-			Variables = new List<VariableExpression>(variables);
-		}
+			reader.Next(TokenType.Space, false);
 
-		public List<VariableExpression> Variables { get; }
-
-		public void Execute(IEnvironment env, bool isImmediate)
-		{
-			env.Print("? ");
-			var reply = env.ReadLine();
-
-			var reader = ComplexTokenReader.FromText(reply);
-
-			var isFirst = true;
-			foreach (var v in Variables)
+			if (!isFirst)
 			{
-				reader.Next(TokenType.Space, false);
-
-				if (!isFirst)
-				{
-					reader.Next(TokenType.Comma);
-					reader.Next(TokenType.Space, false);
-				}
-				isFirst = false;
-
-				var number = reader.NextNumber(false);
-				if (number == null)
-				{
-					var token = reader.Next();
-					if (token == null)
-					{
-						throw new RuntimeException("OUT OF INPUT", env.CurrentLineNumber);
-					}
-
-					var text = token.Text.Trim();
-					if (token.Type == TokenType.String)
-					{
-						text = text.Substring(1, text.Length - 2);
-					}
-
-					// Assign a string.
-					env.SetStringVariableValue(v.Name, text);
-				}
-				else
-				{
-					// Assign a number.
-					env.SetNumericVariableValue(v.Name, number.Value);
-				}
-
+				reader.Next(TokenType.Comma);
 				reader.Next(TokenType.Space, false);
 			}
+			isFirst = false;
 
-			if (reader.Next() != null)
+			var number = reader.NextNumber(false);
+			if (number == null)
 			{
-				throw new RuntimeException("TOO MUCH INPUT", env.CurrentLineNumber);
+				var token = reader.Next();
+				if (token == null)
+				{
+					throw new RuntimeException("OUT OF INPUT", env.CurrentLineNumber);
+				}
+
+				var text = token.Text.Trim();
+				if (token.Type == TokenType.String)
+				{
+					text = text.Substring(1, text.Length - 2);
+				}
+
+				// Assign a string.
+				env.SetStringVariableValue(v.Name, text);
 			}
+			else
+			{
+				// Assign a number.
+				env.SetNumericVariableValue(v.Name, number.Value);
+			}
+
+			reader.Next(TokenType.Space, false);
 		}
 
-		public string ToListing()
+		if (reader.Next() != null)
 		{
-			return string.Concat("INPUT ", string.Join(",", Variables.Select(x => x.ToListing())));
+			throw new RuntimeException("TOO MUCH INPUT", env.CurrentLineNumber);
 		}
+	}
+
+	public string ToListing()
+	{
+		return string.Concat("INPUT ", string.Join(",", Variables.Select(x => x.ToListing())));
 	}
 }

--- a/src/ECMABasic.Core/Statements/LetStatement.cs
+++ b/src/ECMABasic.Core/Statements/LetStatement.cs
@@ -1,35 +1,34 @@
 ﻿using ECMABasic.Core.Expressions;
 using System;
 
-namespace ECMABasic.Core.Statements
+namespace ECMABasic.Core.Statements;
+
+public class LetStatement : IStatement
 {
-	public class LetStatement : IStatement
+	public LetStatement(VariableExpression targetExpr, IExpression valueExpr)
 	{
-		public LetStatement(VariableExpression targetExpr, IExpression valueExpr)
-		{
-			Target = targetExpr;
-			Value = valueExpr;
-		}
+		Target = targetExpr;
+		Value = valueExpr;
+	}
 
-		public VariableExpression Target { get; }
-		public IExpression Value { get; }
+	public VariableExpression Target { get; }
+	public IExpression Value { get; }
 
-		public void Execute(IEnvironment env, bool isImmediate)
+	public void Execute(IEnvironment env, bool isImmediate)
+	{
+		var value = Value.Evaluate(env);
+		if (Target.IsString)
 		{
-			var value = Value.Evaluate(env);
-			if (Target.IsString)
-			{
-				env.SetStringVariableValue(Target.Name, Convert.ToString(value) ?? string.Empty);
-			}
-			else
-			{
-				env.SetNumericVariableValue(Target.Name, Convert.ToDouble(value));
-			}
+			env.SetStringVariableValue(Target.Name, Convert.ToString(value) ?? string.Empty);
 		}
+		else
+		{
+			env.SetNumericVariableValue(Target.Name, Convert.ToDouble(value));
+		}
+	}
 
-		public string ToListing()
-		{
-			return string.Concat("LET ", Target.ToListing(), "=", Value.ToListing());
-		}
+	public string ToListing()
+	{
+		return string.Concat("LET ", Target.ToListing(), "=", Value.ToListing());
 	}
 }

--- a/src/ECMABasic.Core/Statements/NextStatement.cs
+++ b/src/ECMABasic.Core/Statements/NextStatement.cs
@@ -1,64 +1,63 @@
 ﻿using ECMABasic.Core.Expressions;
 using System;
 
-namespace ECMABasic.Core.Statements
+namespace ECMABasic.Core.Statements;
+
+public class NextStatement : IStatement
 {
-	public class NextStatement : IStatement
+	public NextStatement(VariableExpression loopVar)
 	{
-		public NextStatement(VariableExpression loopVar)
+		if (!loopVar.IsNumeric)
 		{
-			if (!loopVar.IsNumeric)
-			{
-				throw ExceptionFactory.ExpectedNumericVariable();
-			}
-			LoopVar = loopVar;
+			throw ExceptionFactory.ExpectedNumericVariable();
+		}
+		LoopVar = loopVar;
+	}
+
+	public VariableExpression LoopVar { get; }
+
+	public void Execute(IEnvironment env, bool isImmediate)
+	{
+		if (env.PopCallStack() is not ForStackContext context)
+		{
+			throw ExceptionFactory.NextWithoutFor(env.CurrentLineNumber);
 		}
 
-		public VariableExpression LoopVar { get; }
-
-		public void Execute(IEnvironment env, bool isImmediate)
+		if (context.LoopVar.Name != LoopVar.Name)
 		{
-			if (env.PopCallStack() is not ForStackContext context)
-			{
-				throw ExceptionFactory.NextWithoutFor(env.CurrentLineNumber);
-			}
-
-			if (context.LoopVar.Name != LoopVar.Name)
-			{
-				throw ExceptionFactory.NextWithoutFor(env.CurrentLineNumber);
-			}
-			 
-			if (!context.BlockEndLineNumber.HasValue)
-			{
-				var blockEndLineNumber = env.Program.GetNextLineNumber(env.CurrentLineNumber);
-				context.BlockEndLineNumber = blockEndLineNumber;
-			}
-
-			env.CurrentLineNumber = context.BlockStartLineNumber;
-			env.PushCallStack(context);  // We'll stay in the FOR-NEXT context until the FOR statement says we're done.
-
-			//var loopVar = Convert.ToDouble(context.LoopVar.Evaluate(env));
-			//var to = Convert.ToDouble(context.To.Evaluate(env));
-			//var step = Convert.ToDouble(context.Step.Evaluate(env));
-
-			//loopVar += step;
-			//env.SetNumericVariableValue(LoopVar.Name, loopVar);
-
-			//if (((step < 0) && (loopVar < to)) || ((step > 0) && (loopVar > to)))
-			//{
-			//	// We're done.
-			//}
-			//else
-			//{
-			//	// Goto loop start.
-			//	env.CurrentLineNumber = context.BlockStartLineNumber;
-			//	env.PushCallStack(context);  // We're still in the FOR-NEXT context.
-			//}
+			throw ExceptionFactory.NextWithoutFor(env.CurrentLineNumber);
+		}
+		 
+		if (!context.BlockEndLineNumber.HasValue)
+		{
+			var blockEndLineNumber = env.Program.GetNextLineNumber(env.CurrentLineNumber);
+			context.BlockEndLineNumber = blockEndLineNumber;
 		}
 
-		public string ToListing()
-		{
-			return string.Concat("NEXT ", LoopVar.ToListing());
-		}
+		env.CurrentLineNumber = context.BlockStartLineNumber;
+		env.PushCallStack(context);  // We'll stay in the FOR-NEXT context until the FOR statement says we're done.
+
+		//var loopVar = Convert.ToDouble(context.LoopVar.Evaluate(env));
+		//var to = Convert.ToDouble(context.To.Evaluate(env));
+		//var step = Convert.ToDouble(context.Step.Evaluate(env));
+
+		//loopVar += step;
+		//env.SetNumericVariableValue(LoopVar.Name, loopVar);
+
+		//if (((step < 0) && (loopVar < to)) || ((step > 0) && (loopVar > to)))
+		//{
+		//	// We're done.
+		//}
+		//else
+		//{
+		//	// Goto loop start.
+		//	env.CurrentLineNumber = context.BlockStartLineNumber;
+		//	env.PushCallStack(context);  // We're still in the FOR-NEXT context.
+		//}
+	}
+
+	public string ToListing()
+	{
+		return string.Concat("NEXT ", LoopVar.ToListing());
 	}
 }

--- a/src/ECMABasic.Core/Statements/OnGotoStatement.cs
+++ b/src/ECMABasic.Core/Statements/OnGotoStatement.cs
@@ -3,39 +3,38 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace ECMABasic.Core.Statements
+namespace ECMABasic.Core.Statements;
+
+public class OnGotoStatement : IStatement
 {
-	public class OnGotoStatement : IStatement
+	public OnGotoStatement(IExpression value, IEnumerable<IExpression> branches)
 	{
-		public OnGotoStatement(IExpression value, IEnumerable<IExpression> branches)
+		if ((value.Type != ExpressionType.Number) || branches.Any(x => x.Type != ExpressionType.Number))
 		{
-			if ((value.Type != ExpressionType.Number) || branches.Any(x => x.Type != ExpressionType.Number))
-			{
-				throw ExceptionFactory.ExpectedNumericExpression();
-			}
-			Value = value;
-			Branches = new List<IExpression>(branches);
+			throw ExceptionFactory.ExpectedNumericExpression();
+		}
+		Value = value;
+		Branches = new List<IExpression>(branches);
+	}
+
+	public IExpression Value { get; }
+	public List<IExpression> Branches { get; }
+
+	public void Execute(IEnvironment env, bool isImmediate)
+	{
+		// Subtract 1 from value because BASIC arrays start with 1.
+		var value = Convert.ToInt32(Value.Evaluate(env)) - 1;
+		if ((value < 0) || (value >= Branches.Count))
+		{
+			throw ExceptionFactory.IndexOutOfRange(env.CurrentLineNumber);
 		}
 
-		public IExpression Value { get; }
-		public List<IExpression> Branches { get; }
+		var lineNumber = Convert.ToInt32(Branches[value].Evaluate(env));
+		env.CurrentLineNumber = lineNumber;
+	}
 
-		public void Execute(IEnvironment env, bool isImmediate)
-		{
-			// Subtract 1 from value because BASIC arrays start with 1.
-			var value = Convert.ToInt32(Value.Evaluate(env)) - 1;
-			if ((value < 0) || (value >= Branches.Count))
-			{
-				throw ExceptionFactory.IndexOutOfRange(env.CurrentLineNumber);
-			}
-
-			var lineNumber = Convert.ToInt32(Branches[value].Evaluate(env));
-			env.CurrentLineNumber = lineNumber;
-		}
-
-		public string ToListing()
-		{
-			return string.Concat("ON ", Value.ToListing(), " GOTO ", string.Join(",", Branches.Select(x => x.ToListing())));
-		}
+	public string ToListing()
+	{
+		return string.Concat("ON ", Value.ToListing(), " GOTO ", string.Join(",", Branches.Select(x => x.ToListing())));
 	}
 }

--- a/src/ECMABasic.Core/Statements/PrintStatement.cs
+++ b/src/ECMABasic.Core/Statements/PrintStatement.cs
@@ -3,119 +3,118 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace ECMABasic.Core.Statements
+namespace ECMABasic.Core.Statements;
+
+public class PrintStatement : IStatement
 {
-	public class PrintStatement : IStatement
+	private readonly string _scientificFormat;
+	private readonly string _numberFormat;
+
+	private readonly IBasicConfiguration _config;
+
+	public PrintStatement(IEnumerable<IPrintItem>? expr = null, IBasicConfiguration? config = null)
 	{
-		private readonly string _scientificFormat;
-		private readonly string _numberFormat;
-
-		private readonly IBasicConfiguration _config;
-
-		public PrintStatement(IEnumerable<IPrintItem>? expr = null, IBasicConfiguration? config = null)
+		_config = config ?? MinimalBasicConfiguration.Instance;
+		if (_scientificFormat == null)
 		{
-			_config = config ?? MinimalBasicConfiguration.Instance;
-			if (_scientificFormat == null)
-			{
-				_scientificFormat = string.Format(" #.{0}E+{1} ;-#.{0}E+{1} ", new string('#', _config.SignificanceWidth - 1), new string('0', _config.ExradWidth - 1));
-			}
-			if (_numberFormat == null)
-			{
-				_numberFormat = string.Format(" .{0} ;-.{0} ; 0 ", new string('#', _config.SignificanceWidth));
-			}
-
-			PrintItems = new List<IPrintItem>(expr ?? Enumerable.Empty<IPrintItem>());
+			_scientificFormat = string.Format(" #.{0}E+{1} ;-#.{0}E+{1} ", new string('#', _config.SignificanceWidth - 1), new string('0', _config.ExradWidth - 1));
+		}
+		if (_numberFormat == null)
+		{
+			_numberFormat = string.Format(" .{0} ;-.{0} ; 0 ", new string('#', _config.SignificanceWidth));
 		}
 
-		/// <summary>
-		/// The expressions to print.
-		/// </summary>
-		public List<IPrintItem> PrintItems { get; }
+		PrintItems = new List<IPrintItem>(expr ?? Enumerable.Empty<IPrintItem>());
+	}
 
-		public void Execute(IEnvironment env, bool isImmediate)
+	/// <summary>
+	/// The expressions to print.
+	/// </summary>
+	public List<IPrintItem> PrintItems { get; }
+
+	public void Execute(IEnvironment env, bool isImmediate)
+	{
+		if (PrintItems.Count == 0)
 		{
-			if (PrintItems.Count == 0)
-			{
-				env.PrintLine();
-				return;
-			}
-
-			foreach (var expr in PrintItems)
-			{
-				var value = expr.Evaluate(env);
-				var text = value switch
-				{
-					int => PrintNumber((int)value),
-					double => PrintNumber((double)value),
-					_ => Convert.ToString(value),
-				};
-				env.Print(text ?? string.Empty);
-			}
-
-			if (!(PrintItems.Last() is IPrintItemSeparator))
-			{
-				env.PrintLine();
-			}
+			env.PrintLine();
+			return;
 		}
 
-		public string ToListing()
+		foreach (var expr in PrintItems)
 		{
-			return string.Concat("PRINT ", string.Join(string.Empty, PrintItems.Select(x => x.ToListing())));
+			var value = expr.Evaluate(env);
+			var text = value switch
+			{
+				int => PrintNumber((int)value),
+				double => PrintNumber((double)value),
+				_ => Convert.ToString(value),
+			};
+			env.Print(text ?? string.Empty);
 		}
 
-		private string PrintNumber(double value)
+		if (!(PrintItems.Last() is IPrintItemSeparator))
 		{
-			if ((value == 0) || (value == -0.0))
-			{
-				return " 0 ";
-			}
+			env.PrintLine();
+		}
+	}
 
-			if (value == double.PositiveInfinity)
-			{
-				return " INF ";
-			}
-			else if (value == double.NegativeInfinity)
-			{
-				return "-INF ";
-			}
-			else if (value.Equals(double.NaN))
-			{
-				return " NAN ";
-			}
+	public string ToListing()
+	{
+		return string.Concat("PRINT ", string.Join(string.Empty, PrintItems.Select(x => x.ToListing())));
+	}
 
-			var numDigits = Math.Floor(Math.Log10(Math.Abs(value)));
-			var scale = (double)Math.Pow(10, numDigits + 1);  // Calculate the scale of the number.
-			var newValue = (double)(scale * Math.Round((double)value / scale, _config.SignificanceWidth));  // Reduce the significant digit width.
-			if (numDigits == -_config.SignificanceWidth)
-			{
-				if (Math.Round(value, _config.SignificanceWidth) == value)
-				{
-					return newValue.ToString(_numberFormat);
-				}
-				else
-				{
-					return newValue.ToString(_scientificFormat);
-				}
-			}
-			else if ((numDigits > -_config.SignificanceWidth) && (numDigits <= _config.SignificanceWidth))
+	private string PrintNumber(double value)
+	{
+		if ((value == 0) || (value == -0.0))
+		{
+			return " 0 ";
+		}
+
+		if (value == double.PositiveInfinity)
+		{
+			return " INF ";
+		}
+		else if (value == double.NegativeInfinity)
+		{
+			return "-INF ";
+		}
+		else if (value.Equals(double.NaN))
+		{
+			return " NAN ";
+		}
+
+		var numDigits = Math.Floor(Math.Log10(Math.Abs(value)));
+		var scale = (double)Math.Pow(10, numDigits + 1);  // Calculate the scale of the number.
+		var newValue = (double)(scale * Math.Round((double)value / scale, _config.SignificanceWidth));  // Reduce the significant digit width.
+		if (numDigits == -_config.SignificanceWidth)
+		{
+			if (Math.Round(value, _config.SignificanceWidth) == value)
 			{
 				return newValue.ToString(_numberFormat);
 			}
 			else
 			{
-				var text = newValue.ToString(_scientificFormat);
-				var eIndex = text.IndexOf("E");
-				if (eIndex >= 0)
-				{
-					var dotIndex = text.IndexOf(".");
-					if (dotIndex < 0)
-					{
-						// There should always be a full-stop between the integer and the E.
-						text = text.Insert(eIndex, ".");
-					}
-				}
-				return text;
+				return newValue.ToString(_scientificFormat);
 			}
+		}
+		else if ((numDigits > -_config.SignificanceWidth) && (numDigits <= _config.SignificanceWidth))
+		{
+			return newValue.ToString(_numberFormat);
+		}
+		else
+		{
+			var text = newValue.ToString(_scientificFormat);
+			var eIndex = text.IndexOf("E");
+			if (eIndex >= 0)
+			{
+				var dotIndex = text.IndexOf(".");
+				if (dotIndex < 0)
+				{
+					// There should always be a full-stop between the integer and the E.
+					text = text.Insert(eIndex, ".");
+				}
+			}
+			return text;
 		}
 	}
 }

--- a/src/ECMABasic.Core/Statements/ReadStatement.cs
+++ b/src/ECMABasic.Core/Statements/ReadStatement.cs
@@ -3,44 +3,43 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace ECMABasic.Core.Statements
+namespace ECMABasic.Core.Statements;
+
+public class ReadStatement : IStatement
 {
-	public class ReadStatement : IStatement
+	public ReadStatement(IEnumerable<VariableExpression> variables)
 	{
-		public ReadStatement(IEnumerable<VariableExpression> variables)
-		{
-			Variables = new List<VariableExpression>(variables);
-		}
+		Variables = new List<VariableExpression>(variables);
+	}
 
-		public List<VariableExpression> Variables { get; }
+	public List<VariableExpression> Variables { get; }
 
-		public void Execute(IEnvironment env, bool isImmediate)
+	public void Execute(IEnvironment env, bool isImmediate)
+	{
+		foreach (var v in Variables)
 		{
-			foreach (var v in Variables)
+			var datum = env.ReadData();
+
+			if (datum.Type != v.Type)
 			{
-				var datum = env.ReadData();
+				throw ExceptionFactory.MixedStringsAndNumbers(env.CurrentLineNumber);
+			}
 
-				if (datum.Type != v.Type)
-				{
-					throw ExceptionFactory.MixedStringsAndNumbers(env.CurrentLineNumber);
-				}
+			var datumValue = datum.Evaluate(env);
 
-				var datumValue = datum.Evaluate(env);
-
-				if (v.IsString)
-				{
-					env.SetStringVariableValue(v.Name, Convert.ToString(datumValue) ?? string.Empty);
-				}
-				else
-				{
-					env.SetNumericVariableValue(v.Name, Convert.ToDouble(datumValue));
-				}
+			if (v.IsString)
+			{
+				env.SetStringVariableValue(v.Name, Convert.ToString(datumValue) ?? string.Empty);
+			}
+			else
+			{
+				env.SetNumericVariableValue(v.Name, Convert.ToDouble(datumValue));
 			}
 		}
+	}
 
-		public string ToListing()
-		{
-			return string.Concat("READ ", string.Join(",", Variables.Select(x => x.ToListing())));
-		}
+	public string ToListing()
+	{
+		return string.Concat("READ ", string.Join(",", Variables.Select(x => x.ToListing())));
 	}
 }

--- a/src/ECMABasic.Core/Statements/RemarkStatement.cs
+++ b/src/ECMABasic.Core/Statements/RemarkStatement.cs
@@ -1,22 +1,21 @@
-﻿namespace ECMABasic.Core.Statements
+﻿namespace ECMABasic.Core.Statements;
+
+public class RemarkStatement : IStatement
 {
-	public class RemarkStatement : IStatement
+	public RemarkStatement(string remark)
 	{
-		public RemarkStatement(string remark)
-		{
-			Remark = remark;
-		}
+		Remark = remark;
+	}
 
-		public string Remark { get; }
+	public string Remark { get; }
 
-		public void Execute(IEnvironment env, bool isImmediate)
-		{
-			// This statement doesn't actually affect the environment at all.
-		}
+	public void Execute(IEnvironment env, bool isImmediate)
+	{
+		// This statement doesn't actually affect the environment at all.
+	}
 
-		public string ToListing()
-		{
-			return string.Concat("REM ", Remark);
-		}
+	public string ToListing()
+	{
+		return string.Concat("REM ", Remark);
 	}
 }

--- a/src/ECMABasic.Core/Statements/RestoreStatement.cs
+++ b/src/ECMABasic.Core/Statements/RestoreStatement.cs
@@ -1,15 +1,14 @@
-﻿namespace ECMABasic.Core.Statements
-{
-	public class RestoreStatement : IStatement
-	{
-		public void Execute(IEnvironment env, bool isImmediate)
-		{
-			env.ResetDataPointer();
-		}
+﻿namespace ECMABasic.Core.Statements;
 
-		public string ToListing()
-		{
-			return "RESTORE";
-		}
+public class RestoreStatement : IStatement
+{
+	public void Execute(IEnvironment env, bool isImmediate)
+	{
+		env.ResetDataPointer();
+	}
+
+	public string ToListing()
+	{
+		return "RESTORE";
 	}
 }

--- a/src/ECMABasic.Core/Statements/ReturnStatement.cs
+++ b/src/ECMABasic.Core/Statements/ReturnStatement.cs
@@ -1,48 +1,47 @@
 ﻿using ECMABasic.Core.Exceptions;
 using System;
 
-namespace ECMABasic.Core.Statements
+namespace ECMABasic.Core.Statements;
+
+public class ReturnStatement : IStatement
 {
-	public class ReturnStatement : IStatement
+	public ReturnStatement()
 	{
-		public ReturnStatement()
+	}
+
+	// TODO: Need a "% RETURN WITHOUT GOSUB".  Without the line # if running as an immediate statement.
+
+	public void Execute(IEnvironment env, bool isImmediate)
+	{
+		if (isImmediate)
 		{
+			throw ExceptionFactory.OnlyAllowedInProgram();
 		}
 
-		// TODO: Need a "% RETURN WITHOUT GOSUB".  Without the line # if running as an immediate statement.
-
-		public void Execute(IEnvironment env, bool isImmediate)
+		try
 		{
-			if (isImmediate)
+			while (true)
 			{
-				throw ExceptionFactory.OnlyAllowedInProgram();
-			}
-
-			try
-			{
-				while (true)
+				var context = env.PopCallStack();
+				if (context is null)
 				{
-					var context = env.PopCallStack();
-					if (context is null)
-					{
-						throw ExceptionFactory.ReturnWithoutGosub(env.CurrentLineNumber);
-					}
-					if (context is GosubStackContext)
-					{
-						env.CurrentLineNumber = (context as GosubStackContext)!.LineNumber;
-						break;
-					}
+					throw ExceptionFactory.ReturnWithoutGosub(env.CurrentLineNumber);
+				}
+				if (context is GosubStackContext)
+				{
+					env.CurrentLineNumber = (context as GosubStackContext)!.LineNumber;
+					break;
 				}
 			}
-			catch (InvalidOperationException)
-			{
-				throw ExceptionFactory.ReturnWithoutGosub(env.CurrentLineNumber);
-			}
 		}
-
-		public string ToListing()
+		catch (InvalidOperationException)
 		{
-			return "RETURN";
+			throw ExceptionFactory.ReturnWithoutGosub(env.CurrentLineNumber);
 		}
+	}
+
+	public string ToListing()
+	{
+		return "RETURN";
 	}
 }

--- a/src/ECMABasic.Core/Statements/StopStatement.cs
+++ b/src/ECMABasic.Core/Statements/StopStatement.cs
@@ -1,19 +1,18 @@
 ﻿using ECMABasic.Core.Exceptions;
 
-namespace ECMABasic.Core.Statements
+namespace ECMABasic.Core.Statements;
+
+public class StopStatement : IStatement
 {
-	public class StopStatement : IStatement
+	public void Execute(IEnvironment env, bool isImmediate)
 	{
-		public void Execute(IEnvironment env, bool isImmediate)
-		{
-			throw ExceptionFactory.ProgramStop(env.CurrentLineNumber);
-		}
+		throw ExceptionFactory.ProgramStop(env.CurrentLineNumber);
+	}
 
-		// TODO: Centralize keyword strings to make them easier to change?
+	// TODO: Centralize keyword strings to make them easier to change?
 
-		public string ToListing()
-		{
-			return "STOP";
-		}
+	public string ToListing()
+	{
+		return "STOP";
 	}
 }

--- a/src/ECMABasic.Core/StringExpressionParser.cs
+++ b/src/ECMABasic.Core/StringExpressionParser.cs
@@ -2,173 +2,172 @@
 using ECMABasic.Core.Expressions;
 using System.Collections.Generic;
 
-namespace ECMABasic.Core
+namespace ECMABasic.Core;
+
+public class StringExpressionParser : ExpressionParser
 {
-	public class StringExpressionParser : ExpressionParser
+	public StringExpressionParser(ComplexTokenReader reader, int? lineNumber, bool throwOnError)
+		: base(reader, lineNumber, throwOnError)
 	{
-		public StringExpressionParser(ComplexTokenReader reader, int? lineNumber, bool throwOnError)
-			: base(reader, lineNumber, throwOnError)
+	}
+
+	public override IExpression? Parse()
+	{
+		var left = ParseAtomic(false);
+		if (left == null)
 		{
+			return null;
 		}
 
-		public override IExpression? Parse()
+		var space = _reader.Next(TokenType.Space, false);
+
+		var symbol = ParseBooleanOperator();
+		if (symbol == null)
 		{
-			var left = ParseAtomic(false);
-			if (left == null)
+			if (space != null)
 			{
-				return null;
+				_reader.Rewind();
 			}
-
-			var space = _reader.Next(TokenType.Space, false);
-
-			var symbol = ParseBooleanOperator();
-			if (symbol == null)
-			{
-				if (space != null)
-				{
-					_reader.Rewind();
-				}
-				return left;
-			}
-
-			_reader.Next(TokenType.Space, false);
-
-			IExpression? right;
-			try
-			{
-				right = ParseAtomic(true);
-			}
-			catch (SyntaxException)
-			{
-				if (new NumericExpressionParser(_reader, _lineNumber, false).Parse() != null)
-				{
-					throw ExceptionFactory.MixedStringsAndNumbers(_lineNumber);
-				}
-				else
-				{
-					throw;
-				}
-			}
-
-			if (right == null)
-			{
-				throw ExceptionFactory.ExpectedStringExpression(_lineNumber);
-			}
-
-			try
-			{
-				return symbol.Text switch
-				{
-					"=" => new EqualsExpression(left, right),
-					"<>" => new NotEqualsExpression(left, right),
-					"<" => new LessThanExpression(left, right),
-					"<=" => new LessThanOrEqualExpression(left, right),
-					">" => new GreaterThanExpression(left, right),
-					">=" => new GreaterThanOrEqualExpression(left, right),
-					_ => throw ExceptionFactory.IllegalOperator(_lineNumber),
-				};
-			}
-			catch (SyntaxException ex)
-			{
-				throw new SyntaxException(ex, _lineNumber);
-			}
+			return left;
 		}
 
-		private IExpression? ParseAtomic(bool throwOnError)
+		_reader.Next(TokenType.Space, false);
+
+		IExpression? right;
+		try
 		{
-			var expr = ParseLiteral() ?? ParseVariable() ?? ParseFunction(throwOnError);
-			if ((expr == null) && throwOnError)
-			{
-				throw ExceptionFactory.ExpectedStringExpression(_lineNumber);
-			}
-			return expr;
+			right = ParseAtomic(true);
 		}
-
-		public IExpression? ParseVariable()
+		catch (SyntaxException)
 		{
-			var nameToken = _reader.Next(TokenType.Word, false, @"[A-Z]\$");
-			if (nameToken == null)
+			if (new NumericExpressionParser(_reader, _lineNumber, false).Parse() != null)
 			{
-				return null;
-			}
-
-			return new VariableExpression(nameToken.Text);
-		}
-
-		public IExpression? ParseLiteral()
-		{
-			var valueToken = _reader.Next(TokenType.String, false);
-			if (valueToken == null)
-			{
-				return null;
+				throw ExceptionFactory.MixedStringsAndNumbers(_lineNumber);
 			}
 			else
 			{
-				// The actual string is everything between the "".
-				var text = valueToken.Text[1..^1];
-				return new StringExpression(text);
+				throw;
 			}
 		}
 
-		public IExpression? ParseFunction(bool throwOnError)
+		if (right == null)
 		{
-			var startIndex = _reader.TokenIndex;
-			var nameToken = _reader.Next(TokenType.Word, false);
-			if (nameToken == null)
-			{
-				return null;
-			}
+			throw ExceptionFactory.ExpectedStringExpression(_lineNumber);
+		}
 
-			var dollar = _reader.Next(TokenType.Symbol, false, @"\$");
-			if (dollar == null)
+		try
+		{
+			return symbol.Text switch
 			{
-				_reader.Seek(startIndex);
-				return null;
-			}
-			nameToken = new Token(TokenType.Word, new[] { nameToken, dollar });
+				"=" => new EqualsExpression(left, right),
+				"<>" => new NotEqualsExpression(left, right),
+				"<" => new LessThanExpression(left, right),
+				"<=" => new LessThanOrEqualExpression(left, right),
+				">" => new GreaterThanExpression(left, right),
+				">=" => new GreaterThanOrEqualExpression(left, right),
+				_ => throw ExceptionFactory.IllegalOperator(_lineNumber),
+			};
+		}
+		catch (SyntaxException ex)
+		{
+			throw new SyntaxException(ex, _lineNumber);
+		}
+	}
 
-			_reader.Next(TokenType.OpenParenthesis);
+	private IExpression? ParseAtomic(bool throwOnError)
+	{
+		var expr = ParseLiteral() ?? ParseVariable() ?? ParseFunction(throwOnError);
+		if ((expr == null) && throwOnError)
+		{
+			throw ExceptionFactory.ExpectedStringExpression(_lineNumber);
+		}
+		return expr;
+	}
 
-			var args = new List<IExpression>();
-			while (true)
+	public IExpression? ParseVariable()
+	{
+		var nameToken = _reader.Next(TokenType.Word, false, @"[A-Z]\$");
+		if (nameToken == null)
+		{
+			return null;
+		}
+
+		return new VariableExpression(nameToken.Text);
+	}
+
+	public IExpression? ParseLiteral()
+	{
+		var valueToken = _reader.Next(TokenType.String, false);
+		if (valueToken == null)
+		{
+			return null;
+		}
+		else
+		{
+			// The actual string is everything between the "".
+			var text = valueToken.Text[1..^1];
+			return new StringExpression(text);
+		}
+	}
+
+	public IExpression? ParseFunction(bool throwOnError)
+	{
+		var startIndex = _reader.TokenIndex;
+		var nameToken = _reader.Next(TokenType.Word, false);
+		if (nameToken == null)
+		{
+			return null;
+		}
+
+		var dollar = _reader.Next(TokenType.Symbol, false, @"\$");
+		if (dollar == null)
+		{
+			_reader.Seek(startIndex);
+			return null;
+		}
+		nameToken = new Token(TokenType.Word, new[] { nameToken, dollar });
+
+		_reader.Next(TokenType.OpenParenthesis);
+
+		var args = new List<IExpression>();
+		while (true)
+		{
+			var argExpr = Parse();
+			if (argExpr == null)
 			{
-				var argExpr = Parse();
+				argExpr = new NumericExpressionParser(_reader, _lineNumber, false).Parse();
 				if (argExpr == null)
-				{
-					argExpr = new NumericExpressionParser(_reader, _lineNumber, false).Parse();
-					if (argExpr == null)
-					{
-						break;
-					}
-				}
-
-				args.Add(argExpr);
-
-				var comma = _reader.Next(TokenType.Comma, false, ",");
-				if (comma == null)
 				{
 					break;
 				}
 			}
 
-			_reader.Next(TokenType.CloseParenthesis);
+			args.Add(argExpr);
 
-			foreach (var fndef in FunctionFactory.Instance.Get(nameToken.Text))
+			var comma = _reader.Next(TokenType.Comma, false, ",");
+			if (comma == null)
 			{
-				if (fndef.CanInstantiate(args))
-				{
-					return fndef.Instantiate(args, _lineNumber);
-				}
+				break;
 			}
+		}
 
-			if (throwOnError)
+		_reader.Next(TokenType.CloseParenthesis);
+
+		foreach (var fndef in FunctionFactory.Instance.Get(nameToken.Text))
+		{
+			if (fndef.CanInstantiate(args))
 			{
-				throw ExceptionFactory.UndefinedFunction(_lineNumber);
+				return fndef.Instantiate(args, _lineNumber);
 			}
-			else
-			{
-				return null;
-			}
+		}
+
+		if (throwOnError)
+		{
+			throw ExceptionFactory.UndefinedFunction(_lineNumber);
+		}
+		else
+		{
+			return null;
 		}
 	}
 }

--- a/src/ECMABasic.Core/Token.cs
+++ b/src/ECMABasic.Core/Token.cs
@@ -2,85 +2,84 @@
 using System.Linq;
 using System.Text;
 
-namespace ECMABasic.Core
+namespace ECMABasic.Core;
+
+public class Token
 {
-    public class Token
+    /// <summary>
+    /// Create a token from an aggregate of several other tokens.
+    /// </summary>
+    /// <param name="type">The type of the new token.</param>
+    /// <param name="tokens">The tokens to combine into a single token.</param>
+    public Token(TokenType type, IEnumerable<Token> tokens)
+	{
+        Type = type;
+        Line = tokens.First().Line;
+        Column = tokens.First().Column;
+
+        var sb = new StringBuilder();
+        foreach (var token in tokens)
+		{
+            sb.Append(token.Text);
+		}
+        Text = sb.ToString();
+	}
+
+    /// <summary>
+    /// Clone an existing token, optionally modifying it's type.
+    /// </summary>
+    /// <param name="type">The type of the new token.</param>
+    /// <param name="token">The token to clone.</param>
+    public Token(TokenType type, Token token)
+	{
+        Type = type;
+        Line = token.Line;
+        Column = token.Column;
+        Text = token.Text;
+	}
+
+    /// <summary>
+    /// Create a token.
+    /// </summary>
+    /// <param name="type">The type of the new token.</param>
+    /// <param name="line">The line number in the source text that this token starts on.</param>
+    /// <param name="column">The column number in the source text that this token ends on.</param>
+    /// <param name="text">The full text of the token.</param>
+    public Token(TokenType type, int line, int column, string text)
     {
-        /// <summary>
-        /// Create a token from an aggregate of several other tokens.
-        /// </summary>
-        /// <param name="type">The type of the new token.</param>
-        /// <param name="tokens">The tokens to combine into a single token.</param>
-        public Token(TokenType type, IEnumerable<Token> tokens)
-		{
-            Type = type;
-            Line = tokens.First().Line;
-            Column = tokens.First().Column;
+        Type = type;
+        Line = line;
+        Column = column;
+        Text = text;
+    }
 
-            var sb = new StringBuilder();
-            foreach (var token in tokens)
-			{
-                sb.Append(token.Text);
-			}
-            Text = sb.ToString();
-		}
+    /// <summary>
+    /// What type of token is this?
+    /// </summary>
+    public TokenType Type { get; }
 
-        /// <summary>
-        /// Clone an existing token, optionally modifying it's type.
-        /// </summary>
-        /// <param name="type">The type of the new token.</param>
-        /// <param name="token">The token to clone.</param>
-        public Token(TokenType type, Token token)
-		{
-            Type = type;
-            Line = token.Line;
-            Column = token.Column;
-            Text = token.Text;
-		}
+    /// <summary>
+    /// The line number in the source text that this token starts on.
+    /// </summary>
+    public int Line { get; }
 
-        /// <summary>
-        /// Create a token.
-        /// </summary>
-        /// <param name="type">The type of the new token.</param>
-        /// <param name="line">The line number in the source text that this token starts on.</param>
-        /// <param name="column">The column number in the source text that this token ends on.</param>
-        /// <param name="text">The full text of the token.</param>
-        public Token(TokenType type, int line, int column, string text)
-        {
-            Type = type;
-            Line = line;
-            Column = column;
-            Text = text;
-        }
+    /// <summary>
+    /// The column number in the source text that this token ends on.
+    /// </summary>
+    public int Column { get; }
 
-        /// <summary>
-        /// What type of token is this?
-        /// </summary>
-        public TokenType Type { get; }
+    /// <summary>
+    /// The full text of the token.
+    /// </summary>
+    public string Text { get; }
 
-        /// <summary>
-        /// The line number in the source text that this token starts on.
-        /// </summary>
-        public int Line { get; }
+    /// <summary>
+    /// The full length of this token's text.
+    /// </summary>
+    public int Length => Text.Length;
 
-        /// <summary>
-        /// The column number in the source text that this token ends on.
-        /// </summary>
-        public int Column { get; }
-
-        /// <summary>
-        /// The full text of the token.
-        /// </summary>
-        public string Text { get; }
-
-        /// <summary>
-        /// The full length of this token's text.
-        /// </summary>
-        public int Length => Text.Length;
-
-		public override string ToString()
-		{
-            return $"({Line}:{Column}) {Text}";
-		}
+	public override string ToString()
+	{
+        return $"({Line}:{Column}) {Text}";
 	}
 }

--- a/src/ECMABasic.Core/TokenType.cs
+++ b/src/ECMABasic.Core/TokenType.cs
@@ -1,70 +1,69 @@
-﻿namespace ECMABasic.Core
+﻿namespace ECMABasic.Core;
+
+/// <summary>
+/// All of the token types understood by the language.
+/// </summary>
+public enum TokenType
 {
 	/// <summary>
-	/// All of the token types understood by the language.
+	/// [0-9]+
 	/// </summary>
-	public enum TokenType
-	{
-		/// <summary>
-		/// [0-9]+
-		/// </summary>
-		Integer,
+	Integer,
 
-		/// <summary>
-		/// [A-Z]+
-		/// </summary>
-		Word,
+	/// <summary>
+	/// [A-Z]+
+	/// </summary>
+	Word,
 
-		/// <summary>
-		/// Symbol characters: [!"%&amp;'()*+,-./:;&lt;=&gt;?_#$#@[\\]^`{|}~]+
-		/// </summary>
-		Symbol,
+	/// <summary>
+	/// Symbol characters: [!"%&amp;'()*+,-./:;&lt;=&gt;?_#$#@[\\]^`{|}~]+
+	/// </summary>
+	Symbol,
 
-		/// <summary>
-		/// [ \t]+
-		/// </summary>
-		Space,
+	/// <summary>
+	/// [ \t]+
+	/// </summary>
+	Space,
 
-		/// <summary>
-		/// \x0A\x0D?
-		/// </summary>
-		EndOfLine,
+	/// <summary>
+	/// \x0A\x0D?
+	/// </summary>
+	EndOfLine,
 
-		// Complex tokens start here.
+	// Complex tokens start here.
 
-		/// <summary>
-		/// Anything sitting between 2 double-quotes, inclusive.
-		/// </summary>
-		String,
+	/// <summary>
+	/// Anything sitting between 2 double-quotes, inclusive.
+	/// </summary>
+	String,
 
-		/// <summary>
-		/// The comma in a print-list.
-		/// </summary>
-		Comma,
+	/// <summary>
+	/// The comma in a print-list.
+	/// </summary>
+	Comma,
 
-		/// <summary>
-		/// The semicolon in a print-list.
-		/// </summary>
-		Semicolon,
+	/// <summary>
+	/// The semicolon in a print-list.
+	/// </summary>
+	Semicolon,
 
-		/// <summary>
-		/// Opening parenthesis to a function argument list.
-		/// </summary>
-		OpenParenthesis,
+	/// <summary>
+	/// Opening parenthesis to a function argument list.
+	/// </summary>
+	OpenParenthesis,
 
-		/// <summary>
-		/// closing parenthesis to a function argument list.
-		/// </summary>
-		CloseParenthesis,
+	/// <summary>
+	/// closing parenthesis to a function argument list.
+	/// </summary>
+	CloseParenthesis,
 
-		/// <summary>
-		/// A real number: [0-9]*\.[0-9]+
-		/// </summary>
-		Number,
+	/// <summary>
+	/// A real number: [0-9]*\.[0-9]+
+	/// </summary>
+	Number,
 
-		/// <summary>
-		/// Breaks up a number.
-		/// </summary>
-		DecimalPoint
-	}
+	/// <summary>
+	/// Breaks up a number.
+	/// </summary>
+	DecimalPoint
 }

--- a/src/ECMABasic.Test/BASIC-55/Group1SampleTests.cs
+++ b/src/ECMABasic.Test/BASIC-55/Group1SampleTests.cs
@@ -1,17 +1,16 @@
 ﻿using System.ComponentModel;
 using Xunit;
 
-namespace ECMABasic.Test.BASIC_55
+namespace ECMABasic.Test.BASIC_55;
+
+[Description("Simple PRINTing of string constants")]
+public class Group1SampleTests : SampleTests
 {
-	[Description("Simple PRINTing of string constants")]
-	public class Group1SampleTests : SampleTests
+	[Fact(DisplayName = "P001: Null print and printing quoted strings.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Simple PRINTing of string constants")]
+	public void P001()
 	{
-		[Fact(DisplayName = "P001: Null print and printing quoted strings.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Simple PRINTing of string constants")]
-		public void P001()
-		{
-			RunSample("P001");
-		}
+		RunSample("P001");
 	}
 }

--- a/src/ECMABasic.Test/BASIC-55/Group2SampleTests.cs
+++ b/src/ECMABasic.Test/BASIC-55/Group2SampleTests.cs
@@ -1,41 +1,40 @@
 ﻿using System.ComponentModel;
 using Xunit;
 
-namespace ECMABasic.Test.BASIC_55
+namespace ECMABasic.Test.BASIC_55;
+
+[Description("END and STOP")]
+public class Group2SampleTests : SampleTests
 {
-	[Description("END and STOP")]
-	public class Group2SampleTests : SampleTests
+	[Fact(DisplayName = "P002: The END statement.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "END and STOP")]
+	public void P002()
 	{
-		[Fact(DisplayName = "P002: The END statement.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "END and STOP")]
-		public void P002()
-		{
-			RunSample("P002");
-		}
+		RunSample("P002");
+	}
 
-		[Fact(DisplayName = "P003: Error - Misplaced END statement.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "END and STOP")]
-		public void P003()
-		{
-			RunSample("P003");
-		}
+	[Fact(DisplayName = "P003: Error - Misplaced END statement.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "END and STOP")]
+	public void P003()
+	{
+		RunSample("P003");
+	}
 
-		[Fact(DisplayName = "P004: Error - Missing END statement.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "END and STOP")]
-		public void P004()
-		{
-			RunSample("P004");
-		}
+	[Fact(DisplayName = "P004: Error - Missing END statement.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "END and STOP")]
+	public void P004()
+	{
+		RunSample("P004");
+	}
 
-		[Fact(DisplayName = "P005: The STOP statement.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "END and STOP")]
-		public void P005()
-		{
-			RunSample("P005");
-		}
+	[Fact(DisplayName = "P005: The STOP statement.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "END and STOP")]
+	public void P005()
+	{
+		RunSample("P005");
 	}
 }

--- a/src/ECMABasic.Test/BASIC-55/Group3SampleTests.cs
+++ b/src/ECMABasic.Test/BASIC-55/Group3SampleTests.cs
@@ -1,81 +1,80 @@
 ﻿using System.ComponentModel;
 using Xunit;
 
-namespace ECMABasic.Test.BASIC_55
+namespace ECMABasic.Test.BASIC_55;
+
+[Description("PRINTing and simple assignment(\"LET\")")]
+public class Group3SampleTests : SampleTests
 {
-	[Description("PRINTing and simple assignment(\"LET\")")]
-	public class Group3SampleTests : SampleTests
+	[Fact(DisplayName = "P006: PRINT separators, TABs, and string variables.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "String variables and TAB")]
+	public void P006()
 	{
-		[Fact(DisplayName = "P006: PRINT separators, TABs, and string variables.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "String variables and TAB")]
-		public void P006()
-		{
-			RunSample("P006");
-		}
+		RunSample("P006");
+	}
 
-		[Fact(DisplayName = "P007: Exception - String overflow using the LET statement.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "String variables and TAB")]
-		public void P007()
-		{
-			RunSample("P007");
-		}
+	[Fact(DisplayName = "P007: Exception - String overflow using the LET statement.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "String variables and TAB")]
+	public void P007()
+	{
+		RunSample("P007");
+	}
 
-		[Fact(DisplayName = "P008: Exception - TAB argument.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "String variables and TAB")]
-		public void P008()
-		{
-			RunSample("P008");
-		}
+	[Fact(DisplayName = "P008: Exception - TAB argument.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "String variables and TAB")]
+	public void P008()
+	{
+		RunSample("P008");
+	}
 
-		[Fact(DisplayName = "P009: Printing NR1 and NR2 numeric constants.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Numeric constants and variables")]
-		public void P009()
-		{
-			RunSample("P009");
-		}
+	[Fact(DisplayName = "P009: Printing NR1 and NR2 numeric constants.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Numeric constants and variables")]
+	public void P009()
+	{
+		RunSample("P009");
+	}
 
-		[Fact(DisplayName = "P010: Printing NR3 numeric constants.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Numeric constants and variables")]
-		public void P010()
-		{
-			RunSample("P010");
-		}
+	[Fact(DisplayName = "P010: Printing NR3 numeric constants.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Numeric constants and variables")]
+	public void P010()
+	{
+		RunSample("P010");
+	}
 
-		[Fact(DisplayName = "P011: Printing numeric variables assigned NR1 and NR2 constants.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Numeric constants and variables")]
-		public void P011()
-		{
-			RunSample("P011");
-		}
+	[Fact(DisplayName = "P011: Printing numeric variables assigned NR1 and NR2 constants.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Numeric constants and variables")]
+	public void P011()
+	{
+		RunSample("P011");
+	}
 
-		[Fact(DisplayName = "P012: Printing numeric variables assigned NR3 constants.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Numeric constants and variables")]
-		public void P012()
-		{
-			RunSample("P012");
-		}
+	[Fact(DisplayName = "P012: Printing numeric variables assigned NR3 constants.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Numeric constants and variables")]
+	public void P012()
+	{
+		RunSample("P012");
+	}
 
-		[Fact(DisplayName = "P013: Format and rounding of printed numeric constants.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Numeric constants and variables")]
-		public void P013()
-		{
-			RunSample("P013");
-		}
+	[Fact(DisplayName = "P013: Format and rounding of printed numeric constants.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Numeric constants and variables")]
+	public void P013()
+	{
+		RunSample("P013");
+	}
 
-		[Fact(DisplayName = "P014: Printing and assigning numeric values near to the maximum and minimum magnitude.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Numeric constants and variables")]
-		public void P014()
-		{
-			RunSample("P014");
-		}
+	[Fact(DisplayName = "P014: Printing and assigning numeric values near to the maximum and minimum magnitude.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Numeric constants and variables")]
+	public void P014()
+	{
+		RunSample("P014");
 	}
 }

--- a/src/ECMABasic.Test/BASIC-55/Group4SampleTests.cs
+++ b/src/ECMABasic.Test/BASIC-55/Group4SampleTests.cs
@@ -1,65 +1,64 @@
 ﻿using System.ComponentModel;
 using Xunit;
 
-namespace ECMABasic.Test.BASIC_55
+namespace ECMABasic.Test.BASIC_55;
+
+[Description("Control Statements and REM")]
+public class Group4SampleTests : SampleTests
 {
-	[Description("Control Statements and REM")]
-	public class Group4SampleTests : SampleTests
+	[Fact(DisplayName = "P015: The REM and GOTO statements.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Control Statements and REM")]
+	public void P015_The_REM_and_GOTO_statements()
 	{
-		[Fact(DisplayName = "P015: The REM and GOTO statements.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Control Statements and REM")]
-		public void P015_The_REM_and_GOTO_statements()
-		{
-			RunSample("P015");
-		}
+		RunSample("P015");
+	}
 
-		[Fact(DisplayName = "P016: Error - Transfer to a non existing line.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Control Statements and REM")]
-		public void P016()
-		{
-			RunSample("P016");
-		}
+	[Fact(DisplayName = "P016: Error - Transfer to a non existing line.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Control Statements and REM")]
+	public void P016()
+	{
+		RunSample("P016");
+	}
 
-		[Fact(DisplayName = "P017: Elementary use of GOSUB and RETURN.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Control Statements and REM")]
-		public void P017()
-		{
-			RunSample("P017");
-		}
+	[Fact(DisplayName = "P017: Elementary use of GOSUB and RETURN.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Control Statements and REM")]
+	public void P017()
+	{
+		RunSample("P017");
+	}
 
-		[Fact(DisplayName = "P018: The IF-THEN statement with string operands.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Control Statements and REM")]
-		public void P018()
-		{
-			RunSample("P018");
-		}
+	[Fact(DisplayName = "P018: The IF-THEN statement with string operands.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Control Statements and REM")]
+	public void P018()
+	{
+		RunSample("P018");
+	}
 
-		[Fact(DisplayName = "P019: The IF-THEN statement with numeric operands.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Control Statements and REM")]
-		public void P019()
-		{
-			RunSample("P019");
-		}
+	[Fact(DisplayName = "P019: The IF-THEN statement with numeric operands.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Control Statements and REM")]
+	public void P019()
+	{
+		RunSample("P019");
+	}
 
-		[Fact(DisplayName = "P020: Error - IF-THEN statement with a string and numeric operand.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Control Statements and REM")]
-		public void P020()
-		{
-			RunSample("P020");
-		}
+	[Fact(DisplayName = "P020: Error - IF-THEN statement with a string and numeric operand.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Control Statements and REM")]
+	public void P020()
+	{
+		RunSample("P020");
+	}
 
-		[Fact(DisplayName = "P021: Error - Transfer to a non-existing line number using the IF-THEN statement.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Control Statements and REM")]
-		public void P021()
-		{
-			RunSample("P021");
-		}
+	[Fact(DisplayName = "P021: Error - Transfer to a non-existing line number using the IF-THEN statement.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Control Statements and REM")]
+	public void P021()
+	{
+		RunSample("P021");
 	}
 }

--- a/src/ECMABasic.Test/BASIC-55/Group5SampleTests.cs
+++ b/src/ECMABasic.Test/BASIC-55/Group5SampleTests.cs
@@ -1,25 +1,24 @@
 ﻿using System.ComponentModel;
 using Xunit;
 
-namespace ECMABasic.Test.BASIC_55
-{
-	[Description("Variables")]
-	public class Group5SampleTests : SampleTests
-	{
-		[Fact(DisplayName = "P022: Numeric and string variable names with the same initial letter.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Variables")]
-		public void P022()
-		{
-			RunSample("P022");
-		}
+namespace ECMABasic.Test.BASIC_55;
 
-		[Fact(DisplayName = "P023: Initialization of string and numeric variables.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Variables")]
-		public void P023()
-		{
-			RunSample("P023");
-		}
+[Description("Variables")]
+public class Group5SampleTests : SampleTests
+{
+	[Fact(DisplayName = "P022: Numeric and string variable names with the same initial letter.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Variables")]
+	public void P022()
+	{
+		RunSample("P022");
+	}
+
+	[Fact(DisplayName = "P023: Initialization of string and numeric variables.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Variables")]
+	public void P023()
+	{
+		RunSample("P023");
 	}
 }

--- a/src/ECMABasic.Test/BASIC-55/Group6SampleTests.cs
+++ b/src/ECMABasic.Test/BASIC-55/Group6SampleTests.cs
@@ -1,169 +1,168 @@
 ﻿using System.ComponentModel;
 using Xunit;
 
-namespace ECMABasic.Test.BASIC_55
+namespace ECMABasic.Test.BASIC_55;
+
+[Description("Numeric Constants, Variables, and Operations")]
+public class Group6SampleTests : SampleTests
 {
-	[Description("Numeric Constants, Variables, and Operations")]
-	public class Group6SampleTests : SampleTests
+	[Fact(DisplayName = "P024: Plus and minus.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Standard Capabilities")]
+	public void P024()
 	{
-		[Fact(DisplayName = "P024: Plus and minus.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Standard Capabilities")]
-		public void P024()
-		{
-			RunSample("P024");
-		}
+		RunSample("P024");
+	}
 
-		[Fact(DisplayName = "P025: Multiple, divide, and involute.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Standard Capabilities")]
-		public void P025()
-		{
-			RunSample("P025");
-		}
+	[Fact(DisplayName = "P025: Multiple, divide, and involute.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Standard Capabilities")]
+	public void P025()
+	{
+		RunSample("P025");
+	}
 
-		[Fact(DisplayName = "P026: Dependence rules for numeric expressions.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Standard Capabilities")]
-		public void P026()
-		{
-			RunSample("P026");
-		}
+	[Fact(DisplayName = "P026: Dependence rules for numeric expressions.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Standard Capabilities")]
+	public void P026()
+	{
+		RunSample("P026");
+	}
 
-		[Fact(DisplayName = "P027: Accuracy of constants and variables.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Standard Capabilities")]
-		public void P027()
-		{
-			RunSample("P027");
-		}
+	[Fact(DisplayName = "P027: Accuracy of constants and variables.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Standard Capabilities")]
+	public void P027()
+	{
+		RunSample("P027");
+	}
 
-		[Fact(DisplayName = "P028: Exception - Division by zero.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Exceptions")]
-		public void P028()
-		{
-			RunSample("P028");
-		}
+	[Fact(DisplayName = "P028: Exception - Division by zero.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Exceptions")]
+	public void P028()
+	{
+		RunSample("P028");
+	}
 
-		[Fact(DisplayName = "P029: Exception - Overflow of numeric expressions.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Exceptions")]
-		public void P029()
-		{
-			RunSample("P029");
-		}
+	[Fact(DisplayName = "P029: Exception - Overflow of numeric expressions.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Exceptions")]
+	public void P029()
+	{
+		RunSample("P029");
+	}
 
-		[Fact(DisplayName = "P030: Exception - Overflow of numeric constants.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Exceptions")]
-		public void P030()
-		{
-			RunSample("P030");
-		}
+	[Fact(DisplayName = "P030: Exception - Overflow of numeric constants.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Exceptions")]
+	public void P030()
+	{
+		RunSample("P030");
+	}
 
-		[Fact(DisplayName = "P031: Exception - Zero raised to a negative power.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Exceptions")]
-		public void P031()
-		{
-			RunSample("P031");
-		}
+	[Fact(DisplayName = "P031: Exception - Zero raised to a negative power.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Exceptions")]
+	public void P031()
+	{
+		RunSample("P031");
+	}
 
-		[Fact(DisplayName = "P032: Exception - Negative quantity raised to a non-integral power.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Exceptions")]
-		public void P032()
-		{
-			RunSample("P032");
-		}
+	[Fact(DisplayName = "P032: Exception - Negative quantity raised to a non-integral power.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Exceptions")]
+	public void P032()
+	{
+		RunSample("P032");
+	}
 
-		[Fact(DisplayName = "P033: Exception - Underflow of numeric expressions.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Exceptions")]
-		public void P033()
-		{
-			RunSample("P033");
-		}
+	[Fact(DisplayName = "P033: Exception - Underflow of numeric expressions.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Exceptions")]
+	public void P033()
+	{
+		RunSample("P033");
+	}
 
-		[Fact(DisplayName = "P034: Exception - Underflow of numeric constants.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Exceptions")]
-		public void P034()
-		{
-			RunSample("P034");
-		}
+	[Fact(DisplayName = "P034: Exception - Underflow of numeric constants.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Exceptions")]
+	public void P034()
+	{
+		RunSample("P034");
+	}
 
-		[Fact(DisplayName = "P035: Exception - Overflow and underflow within sub-expressions.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Exceptions")]
-		public void P035()
-		{
-			RunSample("P035");
-		}
+	[Fact(DisplayName = "P035: Exception - Overflow and underflow within sub-expressions.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Exceptions")]
+	public void P035()
+	{
+		RunSample("P035");
+	}
 
-		[Fact(DisplayName = "P036: Error - Unmatched parenthesis in numeric expressions.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Errors")]
-		public void P036()
-		{
-			RunSample("P036");
-		}
+	[Fact(DisplayName = "P036: Error - Unmatched parenthesis in numeric expressions.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Errors")]
+	public void P036()
+	{
+		RunSample("P036");
+	}
 
-		[Fact(DisplayName = "P037: Error - Use of '**' as operator.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Errors")]
-		public void P037()
-		{
-			RunSample("P037");
-		}
+	[Fact(DisplayName = "P037: Error - Use of '**' as operator.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Errors")]
+	public void P037()
+	{
+		RunSample("P037");
+	}
 
-		[Fact(DisplayName = "P038: Error - Use of adjacent operators.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Errors")]
-		public void P038()
-		{
-			RunSample("P038");
-		}
+	[Fact(DisplayName = "P038: Error - Use of adjacent operators.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Errors")]
+	public void P038()
+	{
+		RunSample("P038");
+	}
 
-		[Fact(DisplayName = "P039: Accuracty of addition.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Accuracy Tests - Informative")]
-		public void P039()
-		{
-			RunSample("P039");
-		}
+	[Fact(DisplayName = "P039: Accuracty of addition.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Accuracy Tests - Informative")]
+	public void P039()
+	{
+		RunSample("P039");
+	}
 
-		[Fact(DisplayName = "P040: Accuracy of subtraction.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Accuracy Tests - Informative")]
-		public void P040()
-		{
-			RunSample("P040");
-		}
+	[Fact(DisplayName = "P040: Accuracy of subtraction.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Accuracy Tests - Informative")]
+	public void P040()
+	{
+		RunSample("P040");
+	}
 
-		[Fact(DisplayName = "P041: Accuracy of multiplication.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Accuracy Tests - Informative")]
-		public void P041()
-		{
-			RunSample("P041");
-		}
+	[Fact(DisplayName = "P041: Accuracy of multiplication.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Accuracy Tests - Informative")]
+	public void P041()
+	{
+		RunSample("P041");
+	}
 
-		[Fact(DisplayName = "P042: Accuracy of division.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Accuracy Tests - Informative")]
-		public void P042()
-		{
-			RunSample("P042");
-		}
+	[Fact(DisplayName = "P042: Accuracy of division.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Accuracy Tests - Informative")]
+	public void P042()
+	{
+		RunSample("P042");
+	}
 
-		[Fact(DisplayName = "P043: Accuracy of involution.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Accuracy Tests - Informative")]
-		public void P043()
-		{
-			RunSample("P043");
-		}
+	[Fact(DisplayName = "P043: Accuracy of involution.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Accuracy Tests - Informative")]
+	public void P043()
+	{
+		RunSample("P043");
 	}
 }

--- a/src/ECMABasic.Test/BASIC-55/Group7SampleTests.cs
+++ b/src/ECMABasic.Test/BASIC-55/Group7SampleTests.cs
@@ -6,105 +6,104 @@ using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace ECMABasic.Test.BASIC_55
+namespace ECMABasic.Test.BASIC_55;
+
+[Description("FOR-NEXT")]
+public class Group7SampleTests : SampleTests
 {
-	[Description("FOR-NEXT")]
-	public class Group7SampleTests : SampleTests
+	[Fact(DisplayName = "P044: Elementary use of the FOR-statement.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Standard Capabilities")]
+	public void P044()
 	{
-		[Fact(DisplayName = "P044: Elementary use of the FOR-statement.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Standard Capabilities")]
-		public void P044()
-		{
-			RunSample("P044");
-		}
+		RunSample("P044");
+	}
 
-		[Fact(DisplayName = "P045: Altering the control-variable within a FOR-block.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Standard Capabilities")]
-		public void P045()
-		{
-			RunSample("P045");
-		}
+	[Fact(DisplayName = "P045: Altering the control-variable within a FOR-block.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Standard Capabilities")]
+	public void P045()
+	{
+		RunSample("P045");
+	}
 
-		[Fact(DisplayName = "P046: Interaction of control statements with the FOR-statement.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Standard Capabilities")]
-		public void P046()
-		{
-			RunSample("P046");
-		}
+	[Fact(DisplayName = "P046: Interaction of control statements with the FOR-statement.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Standard Capabilities")]
+	public void P046()
+	{
+		RunSample("P046");
+	}
 
-		[Fact(DisplayName = "P047: Increment in the STEP clause of the FOR-statement defaults to a value of one.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Standard Capabilities")]
-		public void P047()
-		{
-			RunSample("P047");
-		}
+	[Fact(DisplayName = "P047: Increment in the STEP clause of the FOR-statement defaults to a value of one.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Standard Capabilities")]
+	public void P047()
+	{
+		RunSample("P047");
+	}
 
-		[Fact(DisplayName = "P048: Limit and increment in the FOR-statement are evaluated once upon entering the loop.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Standard Capabilities")]
-		public void P048()
-		{
-			RunSample("P048");
-		}
+	[Fact(DisplayName = "P048: Limit and increment in the FOR-statement are evaluated once upon entering the loop.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Standard Capabilities")]
+	public void P048()
+	{
+		RunSample("P048");
+	}
 
-		[Fact(DisplayName = "P049: Nested FOR-blocks.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Standard Capabilities")]
-		public void P049()
-		{
-			RunSample("P049");
-		}
+	[Fact(DisplayName = "P049: Nested FOR-blocks.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Standard Capabilities")]
+	public void P049()
+	{
+		RunSample("P049");
+	}
 
-		[Fact(DisplayName = "P050: Error - FOR-statement without a matching NEXT-statement.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Errors")]
-		public void P050()
-		{
-			RunSample("P050");
-		}
+	[Fact(DisplayName = "P050: Error - FOR-statement without a matching NEXT-statement.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Errors")]
+	public void P050()
+	{
+		RunSample("P050");
+	}
 
-		[Fact(DisplayName = "P051: Error - NEXT-statement without a matching FOR-statement.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Errors")]
-		public void P051()
-		{
-			RunSample("P051");
-		}
+	[Fact(DisplayName = "P051: Error - NEXT-statement without a matching FOR-statement.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Errors")]
+	public void P051()
+	{
+		RunSample("P051");
+	}
 
-		[Fact(DisplayName = "P052: Error - Mismatched control-variables on FOR-statement and NEXT-statement.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Errors")]
-		public void P052()
-		{
-			RunSample("P052");
-		}
+	[Fact(DisplayName = "P052: Error - Mismatched control-variables on FOR-statement and NEXT-statement.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Errors")]
+	public void P052()
+	{
+		RunSample("P052");
+	}
 
-		[Fact(DisplayName = "P053: Error - Interleaved FOR-blocks.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Errors")]
-		public void P053()
-		{
-			RunSample("P053");
-		}
+	[Fact(DisplayName = "P053: Error - Interleaved FOR-blocks.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Errors")]
+	public void P053()
+	{
+		RunSample("P053");
+	}
 
-		[Fact(DisplayName = "P054: Error - Nested FOR-blocks with the same control variable.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Errors")]
-		public void P054()
-		{
-			RunSample("P054");
-		}
+	[Fact(DisplayName = "P054: Error - Nested FOR-blocks with the same control variable.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Errors")]
+	public void P054()
+	{
+		RunSample("P054");
+	}
 
-		[Fact(DisplayName = "P055: Error - Jump into FOR-block.")]
-		[Trait("Feature Set", "BASIC-55")]
-		[Trait("Category", "Errors")]
-		public void P055()
-		{
-			RunSample("P055");
-		}
+	[Fact(DisplayName = "P055: Error - Jump into FOR-block.")]
+	[Trait("Feature Set", "BASIC-55")]
+	[Trait("Category", "Errors")]
+	public void P055()
+	{
+		RunSample("P055");
 	}
 }

--- a/src/ECMABasic.Test/BASIC-55/InterpreterTests.cs
+++ b/src/ECMABasic.Test/BASIC-55/InterpreterTests.cs
@@ -4,37 +4,36 @@ using System;
 using System.Linq;
 using Xunit;
 
-namespace ECMABasic.Test.BASIC_55
+namespace ECMABasic.Test.BASIC_55;
+
+public class InterpreterTests
 {
-	public class InterpreterTests
+	[Fact]
+	[Trait("Feature Set", "BASIC-55")]
+	public void Can_interpret_PRINT()
 	{
-		[Fact]
-		[Trait("Feature Set", "BASIC-55")]
-		public void Can_interpret_PRINT()
-		{
-			var env = new TestEnvironment();
+		var env = new TestEnvironment();
 
-			var sourceText = @"10 PRINT ""HELLO, WORLD!""
+		var sourceText = @"10 PRINT ""HELLO, WORLD!""
 20 END";
-			Interpreter.FromText(sourceText, env);
-			var program = env.Program;
+		Interpreter.FromText(sourceText, env);
+		var program = env.Program;
 
-			Assert.Equal(2, program.Length);
+		Assert.Equal(2, program.Length);
 
-			var line = program[10];
-			Assert.NotNull(line);
-			Assert.Equal(10, line.LineNumber);
-			Assert.IsType<PrintStatement>(line.Statement);
-			Assert.Equal("HELLO, WORLD!", (line.Statement as PrintStatement).PrintItems.First().Evaluate(env));
+		var line = program[10];
+		Assert.NotNull(line);
+		Assert.Equal(10, line.LineNumber);
+		Assert.IsType<PrintStatement>(line.Statement);
+		Assert.Equal("HELLO, WORLD!", (line.Statement as PrintStatement).PrintItems.First().Evaluate(env));
 
-			line = program[20];
-			Assert.NotNull(line);
-			Assert.Equal(20, line.LineNumber);
-			Assert.IsType<EndStatement>(line.Statement);
+		line = program[20];
+		Assert.NotNull(line);
+		Assert.Equal(20, line.LineNumber);
+		Assert.IsType<EndStatement>(line.Statement);
 
-			program.Execute(env);
+		program.Execute(env);
 
-			Assert.Equal("HELLO, WORLD!" + Environment.NewLine, env.Text);
-		}
+		Assert.Equal("HELLO, WORLD!" + Environment.NewLine, env.Text);
 	}
 }

--- a/src/ECMABasic.Test/BASIC-55/SampleTests.cs
+++ b/src/ECMABasic.Test/BASIC-55/SampleTests.cs
@@ -3,64 +3,63 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace ECMABasic.Test.BASIC_55
+namespace ECMABasic.Test.BASIC_55;
+
+public class SampleTests
 {
-	public class SampleTests
+	protected static void RunSample(string sampleName)
 	{
-		protected static void RunSample(string sampleName)
+		var env = new TestEnvironment();
+
+		var output = File.ReadAllText($"./Resources/{sampleName}.OK");
+		output = NormalizeLineEndings(output);
+		var expectedLines = output.Split(Environment.NewLine);
+
+		if (Interpreter.FromFile($"./Resources/{sampleName}.BAS", env))
 		{
-			var env = new TestEnvironment();
+			env.Program.Execute(env);
+		}
 
-			var output = File.ReadAllText($"./Resources/{sampleName}.OK");
-			output = NormalizeLineEndings(output);
-			var expectedLines = output.Split(Environment.NewLine);
+		var actualLines = env.Text.Split(Environment.NewLine);
 
-			if (Interpreter.FromFile($"./Resources/{sampleName}.BAS", env))
+		//Assert.True(expectedLines.Length >= actualLines.Length);
+
+		for (var line = 0; line < expectedLines.Length; line++)
+		{
+			if (expectedLines[line] != actualLines[line])
 			{
-				env.Program.Execute(env);
-			}
-
-			var actualLines = env.Text.Split(Environment.NewLine);
-
-			//Assert.True(expectedLines.Length >= actualLines.Length);
-
-			for (var line = 0; line < expectedLines.Length; line++)
-			{
-				if (expectedLines[line] != actualLines[line])
+				for (var chn = 0; chn < expectedLines[line].Length; chn++)
 				{
-					for (var chn = 0; chn < expectedLines[line].Length; chn++)
+					if (expectedLines[line][chn] != actualLines[line][chn])
 					{
-						if (expectedLines[line][chn] != actualLines[line][chn])
-						{
-							Assert.True(actualLines[line][chn] == expectedLines[line][chn], $"({line + 1}:{chn + 1}) Expected '{expectedLines[line][chn]}', found '{actualLines[line][chn]}'.");
-						}
+						Assert.True(actualLines[line][chn] == expectedLines[line][chn], $"({line + 1}:{chn + 1}) Expected '{expectedLines[line][chn]}', found '{actualLines[line][chn]}'.");
 					}
 				}
-				else
-				{
-					Assert.Equal(expectedLines[line], actualLines[line]);
-				}
+			}
+			else
+			{
+				Assert.Equal(expectedLines[line], actualLines[line]);
 			}
 		}
+	}
 
-		/// <summary>
-		/// Replace all new-line characters with the currently assigned Environment.NewLine.
-		/// </summary>
-		/// <param name="text">The text to modify.</param>
-		/// <returns>The modified text.</returns>
-		private static string NormalizeLineEndings(string text)
+	/// <summary>
+	/// Replace all new-line characters with the currently assigned Environment.NewLine.
+	/// </summary>
+	/// <param name="text">The text to modify.</param>
+	/// <returns>The modified text.</returns>
+	private static string NormalizeLineEndings(string text)
+	{
+		if (text.Contains("\n"))
 		{
-			if (text.Contains("\n"))
-			{
-				text = text.Replace("\r", string.Empty);
-				text = text.Replace("\n", Environment.NewLine);
-			}
-			else if (text.Contains("\r"))
-			{
-				text = text.Replace("\n", string.Empty);
-				text = text.Replace("\r", Environment.NewLine);
-			}
-			return text;
+			text = text.Replace("\r", string.Empty);
+			text = text.Replace("\n", Environment.NewLine);
 		}
+		else if (text.Contains("\r"))
+		{
+			text = text.Replace("\n", string.Empty);
+			text = text.Replace("\r", Environment.NewLine);
+		}
+		return text;
 	}
 }

--- a/src/ECMABasic.Test/BASIC-55/TokenizerTests.cs
+++ b/src/ECMABasic.Test/BASIC-55/TokenizerTests.cs
@@ -6,201 +6,200 @@ using System.IO;
 using System.Text;
 using Xunit;
 
-namespace ECMABasic.Test.BASIC_55
+namespace ECMABasic.Test.BASIC_55;
+
+public class TokenizerTests
 {
-	public class TokenizerTests
+	[Fact]
+	[Trait("Feature Set", "BASIC-55")]
+	public void Can_create_character_reader()
 	{
-		[Fact]
-		[Trait("Feature Set", "BASIC-55")]
-		public void Can_create_character_reader()
-		{
-			var sourceText = "Hello world!";
-			using var stream = new MemoryStream(Encoding.ASCII.GetBytes(sourceText));
-			using var reader = new CharacterReader(stream);
-			Assert.Equal(sourceText, reader.SourceText);
-			Assert.Equal(sourceText, reader.SourceText);
-		}
+		var sourceText = "Hello world!";
+		using var stream = new MemoryStream(Encoding.ASCII.GetBytes(sourceText));
+		using var reader = new CharacterReader(stream);
+		Assert.Equal(sourceText, reader.SourceText);
+		Assert.Equal(sourceText, reader.SourceText);
+	}
 
-		[Fact]
-		[Trait("Feature Set", "BASIC-55")]
-		public void Can_process_simple_tokens()
+	[Fact]
+	[Trait("Feature Set", "BASIC-55")]
+	public void Can_process_simple_tokens()
+	{
+		var inputText = "HELLO	 123 WORLD!?";
+		using var reader = SimpleTokenReader.FromText(inputText);
+		var tokens = new List<Token>();
+		while (true)
 		{
-			var inputText = "HELLO	 123 WORLD!?";
-			using var reader = SimpleTokenReader.FromText(inputText);
-			var tokens = new List<Token>();
-			while (true)
+			var token = reader.Next();
+			tokens.Add(token);
+			if (token == null)
 			{
-				var token = reader.Next();
-				tokens.Add(token);
-				if (token == null)
-				{
-					break;
-				}
+				break;
 			}
-
-			Assert.Equal(8, tokens.Count);
-
-			Assert.Equal("HELLO", tokens[0].Text);
-			Assert.Equal(TokenType.Word, tokens[0].Type);
-			Assert.Equal(5, tokens[0].Length);
-			Assert.Equal(1, tokens[0].Line);
-			Assert.Equal(1, tokens[0].Column);
-
-			Assert.Equal("	 ", tokens[1].Text);
-			Assert.Equal(TokenType.Space, tokens[1].Type);
-			Assert.Equal(2, tokens[1].Length);
-			Assert.Equal(1, tokens[1].Line);
-			Assert.Equal(6, tokens[1].Column);
-
-			Assert.Equal("123", tokens[2].Text);
-			Assert.Equal(TokenType.Integer, tokens[2].Type);
-			Assert.Equal(3, tokens[2].Length);
-			Assert.Equal(1, tokens[2].Line);
-			Assert.Equal(8, tokens[2].Column);
-
-			Assert.Equal(" ", tokens[3].Text);
-			Assert.Equal(TokenType.Space, tokens[3].Type);
-			Assert.Equal(1, tokens[3].Length);
-			Assert.Equal(1, tokens[3].Line);
-			Assert.Equal(11, tokens[3].Column);
-
-			Assert.Equal("WORLD", tokens[4].Text);
-			Assert.Equal(TokenType.Word, tokens[4].Type);
-			Assert.Equal(5, tokens[4].Length);
-			Assert.Equal(1, tokens[4].Line);
-			Assert.Equal(12, tokens[4].Column);
-
-			Assert.Equal("!", tokens[5].Text);
-			Assert.Equal(TokenType.Symbol, tokens[5].Type);
-			Assert.Equal(1, tokens[5].Length);
-			Assert.Equal(1, tokens[5].Line);
-			Assert.Equal(17, tokens[5].Column);
-
-
-			Assert.Equal("?", tokens[6].Text);
-			Assert.Equal(TokenType.Symbol, tokens[6].Type);
-			Assert.Equal(1, tokens[6].Length);
-			Assert.Equal(1, tokens[6].Line);
-			Assert.Equal(18, tokens[6].Column);
-
-			Assert.Null(tokens[7]);
 		}
 
-		[Fact]
-		[Trait("Feature Set", "BASIC-55")]
-		public void Can_process_complex_tokens()
-		{
-			var input = @"10 PRINT ""HELLO WORLD!""
+		Assert.Equal(8, tokens.Count);
+
+		Assert.Equal("HELLO", tokens[0].Text);
+		Assert.Equal(TokenType.Word, tokens[0].Type);
+		Assert.Equal(5, tokens[0].Length);
+		Assert.Equal(1, tokens[0].Line);
+		Assert.Equal(1, tokens[0].Column);
+
+		Assert.Equal("	 ", tokens[1].Text);
+		Assert.Equal(TokenType.Space, tokens[1].Type);
+		Assert.Equal(2, tokens[1].Length);
+		Assert.Equal(1, tokens[1].Line);
+		Assert.Equal(6, tokens[1].Column);
+
+		Assert.Equal("123", tokens[2].Text);
+		Assert.Equal(TokenType.Integer, tokens[2].Type);
+		Assert.Equal(3, tokens[2].Length);
+		Assert.Equal(1, tokens[2].Line);
+		Assert.Equal(8, tokens[2].Column);
+
+		Assert.Equal(" ", tokens[3].Text);
+		Assert.Equal(TokenType.Space, tokens[3].Type);
+		Assert.Equal(1, tokens[3].Length);
+		Assert.Equal(1, tokens[3].Line);
+		Assert.Equal(11, tokens[3].Column);
+
+		Assert.Equal("WORLD", tokens[4].Text);
+		Assert.Equal(TokenType.Word, tokens[4].Type);
+		Assert.Equal(5, tokens[4].Length);
+		Assert.Equal(1, tokens[4].Line);
+		Assert.Equal(12, tokens[4].Column);
+
+		Assert.Equal("!", tokens[5].Text);
+		Assert.Equal(TokenType.Symbol, tokens[5].Type);
+		Assert.Equal(1, tokens[5].Length);
+		Assert.Equal(1, tokens[5].Line);
+		Assert.Equal(17, tokens[5].Column);
+
+
+		Assert.Equal("?", tokens[6].Text);
+		Assert.Equal(TokenType.Symbol, tokens[6].Type);
+		Assert.Equal(1, tokens[6].Length);
+		Assert.Equal(1, tokens[6].Line);
+		Assert.Equal(18, tokens[6].Column);
+
+		Assert.Null(tokens[7]);
+	}
+
+	[Fact]
+	[Trait("Feature Set", "BASIC-55")]
+	public void Can_process_complex_tokens()
+	{
+		var input = @"10 PRINT ""HELLO WORLD!""
 15 PRINT ""THIS IS A TEST...?""
 20 END";
-			var reader = ComplexTokenReader.FromText(input);
+		var reader = ComplexTokenReader.FromText(input);
 
-			// Line 10
+		// Line 10
 
-			var token = reader.Next();
-			Assert.Equal(TokenType.Integer, token.Type);
-			Assert.Equal("10", token.Text);
+		var token = reader.Next();
+		Assert.Equal(TokenType.Integer, token.Type);
+		Assert.Equal("10", token.Text);
 
-			token = reader.Next();
-			Assert.Equal(TokenType.Space, token.Type);
+		token = reader.Next();
+		Assert.Equal(TokenType.Space, token.Type);
 
-			token = reader.Next();
-			Assert.Equal(TokenType.Word, token.Type);
-			Assert.Equal("PRINT", token.Text);
+		token = reader.Next();
+		Assert.Equal(TokenType.Word, token.Type);
+		Assert.Equal("PRINT", token.Text);
 
-			token = reader.Next();
-			Assert.Equal(TokenType.Space, token.Type);
+		token = reader.Next();
+		Assert.Equal(TokenType.Space, token.Type);
 
-			token = reader.Next();
-			Assert.Equal(TokenType.String, token.Type);
-			Assert.Equal(1, token.Line);
-			Assert.Equal(10, token.Column);
-			Assert.Equal("\"HELLO WORLD!\"", token.Text);
+		token = reader.Next();
+		Assert.Equal(TokenType.String, token.Type);
+		Assert.Equal(1, token.Line);
+		Assert.Equal(10, token.Column);
+		Assert.Equal("\"HELLO WORLD!\"", token.Text);
 
-			token = reader.Next();
-			Assert.Equal(TokenType.EndOfLine, token.Type);
+		token = reader.Next();
+		Assert.Equal(TokenType.EndOfLine, token.Type);
 
-			// Line 15
+		// Line 15
 
-			token = reader.Next();
-			Assert.Equal(TokenType.Integer, token.Type);
-			Assert.Equal("15", token.Text);
+		token = reader.Next();
+		Assert.Equal(TokenType.Integer, token.Type);
+		Assert.Equal("15", token.Text);
 
-			token = reader.Next();
-			Assert.Equal(TokenType.Space, token.Type);
+		token = reader.Next();
+		Assert.Equal(TokenType.Space, token.Type);
 
-			token = reader.Next();
-			Assert.Equal(TokenType.Word, token.Type);
-			Assert.Equal("PRINT", token.Text);
+		token = reader.Next();
+		Assert.Equal(TokenType.Word, token.Type);
+		Assert.Equal("PRINT", token.Text);
 
-			token = reader.Next();
-			Assert.Equal(TokenType.Space, token.Type);
+		token = reader.Next();
+		Assert.Equal(TokenType.Space, token.Type);
 
-			token = reader.Next();
-			Assert.Equal(TokenType.String, token.Type);
-			Assert.Equal("\"THIS IS A TEST...?\"", token.Text);
+		token = reader.Next();
+		Assert.Equal(TokenType.String, token.Type);
+		Assert.Equal("\"THIS IS A TEST...?\"", token.Text);
 
-			token = reader.Next();
-			Assert.Equal(TokenType.EndOfLine, token.Type);
+		token = reader.Next();
+		Assert.Equal(TokenType.EndOfLine, token.Type);
 
-			// Line 20
+		// Line 20
 
-			token = reader.Next();
-			Assert.Equal(TokenType.Integer, token.Type);
-			Assert.Equal("20", token.Text);
+		token = reader.Next();
+		Assert.Equal(TokenType.Integer, token.Type);
+		Assert.Equal("20", token.Text);
 
-			token = reader.Next();
-			Assert.Equal(TokenType.Space, token.Type);
+		token = reader.Next();
+		Assert.Equal(TokenType.Space, token.Type);
 
-			token = reader.Next();
-			Assert.Equal(TokenType.Word, token.Type);
-			Assert.Equal("END", token.Text);
+		token = reader.Next();
+		Assert.Equal(TokenType.Word, token.Type);
+		Assert.Equal("END", token.Text);
 
-			token = reader.Next();
-			Assert.Null(token);
-		}
+		token = reader.Next();
+		Assert.Null(token);
+	}
 
-		[Fact]
-		[Trait("Feature Set", "BASIC-55")]
-		public void Can_recognize_numeric_variables()
-		{
-			var input = @"15 A=5
+	[Fact]
+	[Trait("Feature Set", "BASIC-55")]
+	public void Can_recognize_numeric_variables()
+	{
+		var input = @"15 A=5
 16 B2=10
 20 END";
-			var reader = ComplexTokenReader.FromText(input);
+		var reader = ComplexTokenReader.FromText(input);
 
-			Assert.Equal(15, reader.NextInteger());
-			Assert.Equal(TokenType.Space, reader.Next().Type);
-			Assert.Equal(TokenType.Word, reader.Next().Type);
-			Assert.Equal(TokenType.Symbol, reader.Next().Type);
-			Assert.Equal(5, reader.NextNumber());
-			Assert.Equal(TokenType.EndOfLine, reader.Next().Type);
+		Assert.Equal(15, reader.NextInteger());
+		Assert.Equal(TokenType.Space, reader.Next().Type);
+		Assert.Equal(TokenType.Word, reader.Next().Type);
+		Assert.Equal(TokenType.Symbol, reader.Next().Type);
+		Assert.Equal(5, reader.NextNumber());
+		Assert.Equal(TokenType.EndOfLine, reader.Next().Type);
 
-			Assert.Equal(16, reader.NextInteger());
-			Assert.Equal(TokenType.Space, reader.Next().Type);
-			Assert.Equal(TokenType.Word, reader.Next().Type);
-			Assert.Equal(TokenType.Symbol, reader.Next().Type);
-			Assert.Equal(10, reader.NextNumber());
-			Assert.Equal(TokenType.EndOfLine, reader.Next().Type);
-		}
+		Assert.Equal(16, reader.NextInteger());
+		Assert.Equal(TokenType.Space, reader.Next().Type);
+		Assert.Equal(TokenType.Word, reader.Next().Type);
+		Assert.Equal(TokenType.Symbol, reader.Next().Type);
+		Assert.Equal(10, reader.NextNumber());
+		Assert.Equal(TokenType.EndOfLine, reader.Next().Type);
+	}
 
-		[Fact]
-		[Trait("Feature Set", "BASIC-55")]
-		public void Long_lines_are_rejected()
-		{
-			var input = @"10 PRINT ""HELLO WORLD!""
+	[Fact]
+	[Trait("Feature Set", "BASIC-55")]
+	public void Long_lines_are_rejected()
+	{
+		var input = @"10 PRINT ""HELLO WORLD!""
 20 PRINT ""0123456789012345678901234567890123456789012345678901234567890123456789""
 30 END";
-			using var stream = new MemoryStream(Encoding.ASCII.GetBytes(input));
-			try
-			{
-				var reader = new CharacterReader(stream);
-				throw new InvalidOperationException("This should have thrown an exception.");
-			}
-			catch (SyntaxException ex)
-			{
-				Assert.Equal("? LINE IS TOO LONG BY 9 CHARACTERS IN LINE 20", ex.Message);
-			}
+		using var stream = new MemoryStream(Encoding.ASCII.GetBytes(input));
+		try
+		{
+			var reader = new CharacterReader(stream);
+			throw new InvalidOperationException("This should have thrown an exception.");
+		}
+		catch (SyntaxException ex)
+		{
+			Assert.Equal("? LINE IS TOO LONG BY 9 CHARACTERS IN LINE 20", ex.Message);
 		}
 	}
 }

--- a/src/ECMABasic.Test/TestEnvironment.cs
+++ b/src/ECMABasic.Test/TestEnvironment.cs
@@ -3,75 +3,74 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 
-namespace ECMABasic.Test
+namespace ECMABasic.Test;
+
+internal class TestEnvironment : EnvironmentBase
 {
-	class TestEnvironment : EnvironmentBase
+	private readonly StringBuilder _sb = new();
+	private readonly Queue<string> _inputLines = new();
+
+	public override int TerminalRow { get; set; } = 0;
+
+	public override int TerminalColumn { get; set; } = 0;
+
+	public string Text
 	{
-		private readonly StringBuilder _sb = new();
-		private readonly Queue<string> _inputLines = new();
-
-		public override int TerminalRow { get; set; } = 0;
-
-		public override int TerminalColumn { get; set; } = 0;
-
-		public string Text
+		get
 		{
-			get
-			{
-				return _sb.ToString();
-			}
+			return _sb.ToString();
 		}
+	}
 
-		public string[] Lines
+	public string[] Lines
+	{
+		get
 		{
-			get
-			{
-				return Text.Split('\n');
-			}
+			return Text.Split('\n');
 		}
-		
-		public void AddInputLine(string text)
-		{
-			_inputLines.Enqueue(text);
-		}
+	}
+	
+	public void AddInputLine(string text)
+	{
+		_inputLines.Enqueue(text);
+	}
 
-		public override string ReadLine()
+	public override string ReadLine()
+	{
+		if (_inputLines.Count > 0)
 		{
-			if (_inputLines.Count > 0)
-			{
-				return _inputLines.Dequeue();
-			}
-			return null;
+			return _inputLines.Dequeue();
 		}
+		return null;
+	}
 
-		public override void PrintLine(string text)
-		{
-			Print(text);
-			_sb.AppendLine();
-			Debug.WriteLine(string.Empty);
-			TerminalRow++;
-			TerminalColumn = 0;
-		}
+	public override void PrintLine(string text)
+	{
+		Print(text);
+		_sb.AppendLine();
+		Debug.WriteLine(string.Empty);
+		TerminalRow++;
+		TerminalColumn = 0;
+	}
 
-		public override void Print(string text)
-		{
-			_sb.Append(text);
-			Debug.Write(text);
-			TerminalColumn += text.Length;
-		}
+	public override void Print(string text)
+	{
+		_sb.Append(text);
+		Debug.Write(text);
+		TerminalColumn += text.Length;
+	}
 
-		public override void ReportError(string message)
+	public override void ReportError(string message)
+	{
+		if (TerminalColumn != 0)
 		{
-			if (TerminalColumn != 0)
-			{
-				PrintLine(string.Empty);
-			}
-			PrintLine(message);
+			PrintLine(string.Empty);
 		}
+		PrintLine(message);
+	}
 
-		public override void CheckForStopRequest()
-		{
-			// There's no stopping the test environment.
-		}
+	public override void CheckForStopRequest()
+	{
+		// There's no stopping the test environment.
 	}
 }

--- a/src/ECMABasic55/ConsoleEnvironment.cs
+++ b/src/ECMABasic55/ConsoleEnvironment.cs
@@ -3,70 +3,69 @@ using ECMABasic.Core.Configuration;
 using ECMABasic.Core.Exceptions;
 using System;
 
-namespace ECMABasic55
+namespace ECMABasic55;
+
+public class ConsoleEnvironment : EnvironmentBase
 {
-	public class ConsoleEnvironment : EnvironmentBase
+	public ConsoleEnvironment(Interpreter interpreter = null, IBasicConfiguration config = null)
+		: base(interpreter, config)
 	{
-		public ConsoleEnvironment(Interpreter interpreter = null, IBasicConfiguration config = null)
-			: base(interpreter, config)
-		{
-		}
+	}
 
-		public override int TerminalRow
+	public override int TerminalRow
+	{
+		get
 		{
-			get
+			return Console.CursorTop;
+		}
+		set
+		{
+			Console.CursorTop = value;
+		}
+	}
+
+	public override int TerminalColumn
+	{
+		get
+		{
+			return Console.CursorLeft;
+		}
+		set
+		{
+			Console.CursorLeft = value;
+		}
+	}
+
+	public override string ReadLine()
+	{
+		return Console.ReadLine();
+	}
+
+	public override void PrintLine(string text)
+	{
+		Print(text);
+		Console.WriteLine();
+	}
+
+	public override void Print(string text)
+	{
+		Console.Write(text);
+	}
+
+	public override void ReportError(string message)
+	{
+		PrintLine(string.Empty);
+		PrintLine(message);
+	}
+
+	public override void CheckForStopRequest()
+	{
+		if (Console.KeyAvailable)
+		{
+			var key = Console.ReadKey(true);
+			if (key.Key == ConsoleKey.Escape)
 			{
-				return Console.CursorTop;
-			}
-			set
-			{
-				Console.CursorTop = value;
-			}
-		}
-
-		public override int TerminalColumn
-		{
-			get
-			{
-				return Console.CursorLeft;
-			}
-			set
-			{
-				Console.CursorLeft = value;
-			}
-		}
-
-		public override string ReadLine()
-		{
-			return Console.ReadLine();
-		}
-
-		public override void PrintLine(string text)
-		{
-			Print(text);
-			Console.WriteLine();
-		}
-
-		public override void Print(string text)
-		{
-			Console.Write(text);
-		}
-
-		public override void ReportError(string message)
-		{
-			PrintLine(string.Empty);
-			PrintLine(message);
-		}
-
-		public override void CheckForStopRequest()
-		{
-			if (Console.KeyAvailable)
-			{
-				var key = Console.ReadKey(true);
-				if (key.Key == ConsoleKey.Escape)
-				{
-					throw ExceptionFactory.ProgramStop(CurrentLineNumber);
-				}
+				throw ExceptionFactory.ProgramStop(CurrentLineNumber);
 			}
 		}
 	}

--- a/src/ECMABasic55/Parsers/ContinueStatementParser.cs
+++ b/src/ECMABasic55/Parsers/ContinueStatementParser.cs
@@ -1,22 +1,21 @@
 ﻿using ECMABasic.Core;
 using ECMABasic55.Statements;
 
-namespace ECMABasic55.Parsers
+namespace ECMABasic55.Parsers;
+
+public class ContinueStatementParser : StatementParser
 {
-	public class ContinueStatementParser : StatementParser
+	public override IStatement Parse(ComplexTokenReader reader, int? lineNumber = null)
 	{
-		public override IStatement Parse(ComplexTokenReader reader, int? lineNumber = null)
+		var token = reader.Next(TokenType.Word, false, "CONTINUE");
+		if (token == null)
 		{
-			var token = reader.Next(TokenType.Word, false, "CONTINUE");
+			token = reader.Next(TokenType.Word, false, "CONT");
 			if (token == null)
 			{
-				token = reader.Next(TokenType.Word, false, "CONT");
-				if (token == null)
-				{
-					return null;
-				}
+				return null;
 			}
-			return new ContinueStatement();
 		}
+		return new ContinueStatement();
 	}
 }

--- a/src/ECMABasic55/Parsers/ListStatementParser.cs
+++ b/src/ECMABasic55/Parsers/ListStatementParser.cs
@@ -5,69 +5,68 @@ using ECMABasic.Core.Expressions;
 using ECMABasic55.Statements;
 using System;
 
-namespace ECMABasic55.Parsers
-{
-	public class ListStatementParser : StatementParser
-	{
-		private readonly IBasicConfiguration _config;
+namespace ECMABasic55.Parsers;
 
-		public ListStatementParser(IBasicConfiguration config = null)
+public class ListStatementParser : StatementParser
+{
+	private readonly IBasicConfiguration _config;
+
+	public ListStatementParser(IBasicConfiguration config = null)
+	{
+		_config = config ?? MinimalBasicConfiguration.Instance;
+	}
+
+	public override IStatement Parse(ComplexTokenReader reader, int? lineNumber = null)
+	{
+		var token = reader.Next(TokenType.Word, false, "LIST");
+		if (token == null)
 		{
-			_config = config ?? MinimalBasicConfiguration.Instance;
+			return null;
 		}
 
-		public override IStatement Parse(ComplexTokenReader reader, int? lineNumber = null)
+		if (ProcessSpace(reader, false) == null)
 		{
-			var token = reader.Next(TokenType.Word, false, "LIST");
-			if (token == null)
-			{
-				return null;
-			}
+			return new ListStatement(null, null);
+		}
 
-			if (ProcessSpace(reader, false) == null)
-			{
-				return new ListStatement(null, null);
-			}
+		var expr = ParseNumericExpression(reader, lineNumber, true);
 
-			var expr = ParseNumericExpression(reader, lineNumber, true);
-
-			if (expr is SubtractionExpression)
+		if (expr is SubtractionExpression)
+		{
+			var from = (expr as SubtractionExpression).Left;
+			var to = (expr as SubtractionExpression).Right;
+			return new ListStatement(from, to);
+		}
+		else if (expr is NegationExpression)
+		{
+			var to = (expr as NegationExpression).Root;
+			return new ListStatement(null, to);
+		}
+		else if (expr is NumberExpression)
+		{
+			var val = (expr as NumberExpression).Value;
+			if (val < 0)
 			{
-				var from = (expr as SubtractionExpression).Left;
-				var to = (expr as SubtractionExpression).Right;
-				return new ListStatement(from, to);
-			}
-			else if (expr is NegationExpression)
-			{
-				var to = (expr as NegationExpression).Root;
-				return new ListStatement(null, to);
-			}
-			else if (expr is NumberExpression)
-			{
-				var val = (expr as NumberExpression).Value;
-				if (val < 0)
-				{
-					return new ListStatement(null, (expr as NumberExpression).Negate());
-				}
-				else
-				{
-					var from = expr;
-					var minus = reader.Next(TokenType.Symbol, false, @"\-");
-					if (minus != null)
-					{
-						var to = new NumberExpression(_config.MaxLineNumber);
-						return new ListStatement(from, to);
-					}
-					else
-					{
-						return new ListStatement(from, null);
-					}
-				}
+				return new ListStatement(null, (expr as NumberExpression).Negate());
 			}
 			else
 			{
-				throw ExceptionFactory.LineNumberExpected();
+				var from = expr;
+				var minus = reader.Next(TokenType.Symbol, false, @"\-");
+				if (minus != null)
+				{
+					var to = new NumberExpression(_config.MaxLineNumber);
+					return new ListStatement(from, to);
+				}
+				else
+				{
+					return new ListStatement(from, null);
+				}
 			}
+		}
+		else
+		{
+			throw ExceptionFactory.LineNumberExpected();
 		}
 	}
 }

--- a/src/ECMABasic55/Parsers/LoadStatementParser.cs
+++ b/src/ECMABasic55/Parsers/LoadStatementParser.cs
@@ -1,23 +1,22 @@
 ﻿using ECMABasic.Core;
 using ECMABasic55.Statements;
 
-namespace ECMABasic55.Parsers
+namespace ECMABasic55.Parsers;
+
+public class LoadStatementParser : StatementParser
 {
-	public class LoadStatementParser : StatementParser
+	public override IStatement Parse(ComplexTokenReader reader, int? lineNumber = null)
 	{
-		public override IStatement Parse(ComplexTokenReader reader, int? lineNumber = null)
+		var token = reader.Next(TokenType.Word, false, "LOAD");
+		if (token == null)
 		{
-			var token = reader.Next(TokenType.Word, false, "LOAD");
-			if (token == null)
-			{
-				return null;
-			}
-
-			ProcessSpace(reader);
-
-			var filenameExpr = ParseStringExpression(reader, null, true);
-
-			return new LoadStatement(filenameExpr);
+			return null;
 		}
+
+		ProcessSpace(reader);
+
+		var filenameExpr = ParseStringExpression(reader, null, true);
+
+		return new LoadStatement(filenameExpr);
 	}
 }

--- a/src/ECMABasic55/Parsers/NewStatementParser.cs
+++ b/src/ECMABasic55/Parsers/NewStatementParser.cs
@@ -1,18 +1,17 @@
 ﻿using ECMABasic.Core;
 using ECMABasic55.Statements;
 
-namespace ECMABasic55.Parsers
+namespace ECMABasic55.Parsers;
+
+internal class NewStatementParser : StatementParser
 {
-	class NewStatementParser : StatementParser
+	public override IStatement Parse(ComplexTokenReader reader, int? lineNumber = null)
 	{
-		public override IStatement Parse(ComplexTokenReader reader, int? lineNumber = null)
+		var token = reader.Next(TokenType.Word, false, "NEW");
+		if (token == null)
 		{
-			var token = reader.Next(TokenType.Word, false, "NEW");
-			if (token == null)
-			{
-				return null;
-			}
-			return new NewStatement();
+			return null;
 		}
+		return new NewStatement();
 	}
 }

--- a/src/ECMABasic55/Parsers/RunStatementParser.cs
+++ b/src/ECMABasic55/Parsers/RunStatementParser.cs
@@ -1,26 +1,25 @@
 ﻿using ECMABasic.Core;
 using ECMABasic55.Statements;
 
-namespace ECMABasic55.Parsers
+namespace ECMABasic55.Parsers;
+
+public class RunStatementParser : StatementParser
 {
-	public class RunStatementParser : StatementParser
+	public override IStatement Parse(ComplexTokenReader reader, int? lineNumber = null)
 	{
-		public override IStatement Parse(ComplexTokenReader reader, int? lineNumber = null)
+		var token = reader.Next(TokenType.Word, false, "RUN");
+		if (token == null)
 		{
-			var token = reader.Next(TokenType.Word, false, "RUN");
-			if (token == null)
-			{
-				return null;
-			}
-
-			if (ProcessSpace(reader, false) == null)
-			{
-				return new RunStatement(null);
-			}
-
-			var lineNumberExpr = ParseNumericExpression(reader, lineNumber, false);
-
-			return new RunStatement(lineNumberExpr);
+			return null;
 		}
+
+		if (ProcessSpace(reader, false) == null)
+		{
+			return new RunStatement(null);
+		}
+
+		var lineNumberExpr = ParseNumericExpression(reader, lineNumber, false);
+
+		return new RunStatement(lineNumberExpr);
 	}
 }

--- a/src/ECMABasic55/Parsers/SaveStatementParser.cs
+++ b/src/ECMABasic55/Parsers/SaveStatementParser.cs
@@ -1,23 +1,22 @@
 ﻿using ECMABasic.Core;
 using ECMABasic55.Statements;
 
-namespace ECMABasic55.Parsers
+namespace ECMABasic55.Parsers;
+
+public class SaveStatementParser : StatementParser
 {
-	public class SaveStatementParser : StatementParser
+	public override IStatement Parse(ComplexTokenReader reader, int? lineNumber = null)
 	{
-		public override IStatement Parse(ComplexTokenReader reader, int? lineNumber = null)
+		var token = reader.Next(TokenType.Word, false, "SAVE");
+		if (token == null)
 		{
-			var token = reader.Next(TokenType.Word, false, "SAVE");
-			if (token == null)
-			{
-				return null;
-			}
-
-			ProcessSpace(reader);
-
-			var filenameExpr = ParseStringExpression(reader, null, true);
-
-			return new SaveStatement(filenameExpr);
+			return null;
 		}
+
+		ProcessSpace(reader);
+
+		var filenameExpr = ParseStringExpression(reader, null, true);
+
+		return new SaveStatement(filenameExpr);
 	}
 }

--- a/src/ECMABasic55/Parsers/SleepStatementParser.cs
+++ b/src/ECMABasic55/Parsers/SleepStatementParser.cs
@@ -1,21 +1,20 @@
 ﻿using ECMABasic.Core;
 using ECMABasic55.Statements;
 
-namespace ECMABasic55.Parsers
+namespace ECMABasic55.Parsers;
+
+public class SleepStatementParser : StatementParser
 {
-	public class SleepStatementParser : StatementParser
+	public override IStatement Parse(ComplexTokenReader reader, int? lineNumber = null)
 	{
-		public override IStatement Parse(ComplexTokenReader reader, int? lineNumber = null)
+		if (reader.Next(TokenType.Word, false, @"SLEEP") == null)
 		{
-			if (reader.Next(TokenType.Word, false, @"SLEEP") == null)
-			{
-				return null;
-			}
-
-			ProcessSpace(reader, true);
-
-			var milliseconds = ParseNumericExpression(reader, lineNumber, true);
-			return new SleepStatement(milliseconds);
+			return null;
 		}
+
+		ProcessSpace(reader, true);
+
+		var milliseconds = ParseNumericExpression(reader, lineNumber, true);
+		return new SleepStatement(milliseconds);
 	}
 }

--- a/src/ECMABasic55/Program.cs
+++ b/src/ECMABasic55/Program.cs
@@ -4,119 +4,118 @@ using System;
 using System.IO;
 using System.Text;
 
-namespace ECMABasic55
+namespace ECMABasic55;
+
+// TODO: Better error checking around INPUT.
+// TODO: DATA string datums shouldn't require quotes.
+
+public static class Program
 {
-    // TODO: Better error checking around INPUT.
-    // TODO: DATA string datums shouldn't require quotes.
-
-    public static class Program
+    public static int Main(string[] args)
     {
-        public static int Main(string[] args)
-        {
-            if (args.Length == 1)
-			{
-                return RunBatch(args[0]);
-			}
-            else
-			{
-                return RunREPL();
-			}
-        }
-
-        private static void InjectSpecials(IEnvironment env)
+        if (args.Length == 1)
 		{
-            env.Interpreter.InjectStatements(new[] {
-                new SleepStatementParser(),
-            });
-
-            FunctionFactory.Instance.Define("ASC", new[] { ExpressionType.String }, args => (int)args[0].ToString()[0]);
-
-            FunctionFactory.Instance.Define("MID$", new[] { ExpressionType.String, ExpressionType.Number, ExpressionType.Number }, args =>
-            {
-                var source = Convert.ToString(args[0]);
-                var startIndex = Convert.ToInt32(args[1]);
-                var length = Convert.ToInt32(args[2]);
-                return source.Substring(startIndex - 1, length);
-            });
-
-            FunctionFactory.Instance.Define("MID$", new[] { ExpressionType.String, ExpressionType.Number }, args =>
-            {
-                var source = Convert.ToString(args[0]);
-                var startIndex = Convert.ToInt32(args[1]);
-                var length = Convert.ToInt32(args[2]);
-                return source[(startIndex - 1)..];
-            });
-
-            FunctionFactory.Instance.Define("POS", new[] { ExpressionType.String, ExpressionType.String, ExpressionType.Number }, args =>
-            {
-                var source = Convert.ToString(args[0]);
-                var value = Convert.ToString(args[1]);
-                var index = Convert.ToInt32(args[2]);
-                return (double)source.IndexOf(value, index - 1) + 1;
-            });
-
-            FunctionFactory.Instance.Define("POS", new[] { ExpressionType.String, ExpressionType.String }, args =>
-            {
-                var source = Convert.ToString(args[0]);
-                var value = Convert.ToString(args[1]);
-                return (double)source.IndexOf(value) + 1;
-            });
-        }
-
-        private static int RunBatch(string path)
+            return RunBatch(args[0]);
+		}
+        else
 		{
-			IEnvironment env = new ConsoleEnvironment();
-            InjectSpecials(env);
-            env.PrintLine(RuntimeConfiguration.Instance.Preamble);
-            env.PrintLine();
-
-            if (!File.Exists(path))
-            {
-                throw new FileNotFoundException(null, path);
-            }
-
-            if (env.LoadFile(path))
-            {
-                env.Program.Execute(env);
-                return 0;
-            }
-            else
-			{
-                return -1;
-			}
-        }
-
-        private static int RunREPL()
-		{
-            IEnvironment env = new ConsoleEnvironment(new RuntimeInterpreter());
-            InjectSpecials(env);
-            env.PrintLine(RuntimeConfiguration.Instance.Preamble);
-            env.PrintLine();
-
-            var isRunning = true;
-            Console.WriteLine("OK");
-
-            while (isRunning)
-			{
-                var line = Console.ReadLine() + Environment.NewLine;
-
-				try
-				{
-                    var statement = (env.Interpreter as RuntimeInterpreter).ProcessImmediate(env, line);
-                    if (statement != null)
-					{
-                        statement.Execute(env, true);
-                        Console.WriteLine();
-                        Console.WriteLine("OK");
-                    }
-                }
-				catch (Exception ex)
-				{
-                    Console.WriteLine(ex.Message);
-				}
-			}
-
-			return 0;
+            return RunREPL();
 		}
     }
+
+    private static void InjectSpecials(IEnvironment env)
+	{
+        env.Interpreter.InjectStatements(new[] {
+            new SleepStatementParser(),
+        });
+
+        FunctionFactory.Instance.Define("ASC", new[] { ExpressionType.String }, args => (int)args[0].ToString()[0]);
+
+        FunctionFactory.Instance.Define("MID$", new[] { ExpressionType.String, ExpressionType.Number, ExpressionType.Number }, args =>
+        {
+            var source = Convert.ToString(args[0]);
+            var startIndex = Convert.ToInt32(args[1]);
+            var length = Convert.ToInt32(args[2]);
+            return source.Substring(startIndex - 1, length);
+        });
+
+        FunctionFactory.Instance.Define("MID$", new[] { ExpressionType.String, ExpressionType.Number }, args =>
+        {
+            var source = Convert.ToString(args[0]);
+            var startIndex = Convert.ToInt32(args[1]);
+            var length = Convert.ToInt32(args[2]);
+            return source[(startIndex - 1)..];
+        });
+
+        FunctionFactory.Instance.Define("POS", new[] { ExpressionType.String, ExpressionType.String, ExpressionType.Number }, args =>
+        {
+            var source = Convert.ToString(args[0]);
+            var value = Convert.ToString(args[1]);
+            var index = Convert.ToInt32(args[2]);
+            return (double)source.IndexOf(value, index - 1) + 1;
+        });
+
+        FunctionFactory.Instance.Define("POS", new[] { ExpressionType.String, ExpressionType.String }, args =>
+        {
+            var source = Convert.ToString(args[0]);
+            var value = Convert.ToString(args[1]);
+            return (double)source.IndexOf(value) + 1;
+        });
+    }
+
+    private static int RunBatch(string path)
+	{
+		IEnvironment env = new ConsoleEnvironment();
+        InjectSpecials(env);
+        env.PrintLine(RuntimeConfiguration.Instance.Preamble);
+        env.PrintLine();
+
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException(null, path);
+        }
+
+        if (env.LoadFile(path))
+        {
+            env.Program.Execute(env);
+            return 0;
+        }
+        else
+		{
+            return -1;
+		}
+    }
+
+    private static int RunREPL()
+	{
+        IEnvironment env = new ConsoleEnvironment(new RuntimeInterpreter());
+        InjectSpecials(env);
+        env.PrintLine(RuntimeConfiguration.Instance.Preamble);
+        env.PrintLine();
+
+        var isRunning = true;
+        Console.WriteLine("OK");
+
+        while (isRunning)
+		{
+            var line = Console.ReadLine() + Environment.NewLine;
+
+			try
+			{
+                var statement = (env.Interpreter as RuntimeInterpreter).ProcessImmediate(env, line);
+                if (statement != null)
+				{
+                    statement.Execute(env, true);
+                    Console.WriteLine();
+                    Console.WriteLine("OK");
+                }
+            }
+			catch (Exception ex)
+			{
+                Console.WriteLine(ex.Message);
+			}
+		}
+
+		return 0;
+	}
 }

--- a/src/ECMABasic55/RuntimeConfiguration.cs
+++ b/src/ECMABasic55/RuntimeConfiguration.cs
@@ -1,37 +1,36 @@
 ﻿using Microsoft.Extensions.Configuration;
 using System;
 
-namespace ECMABasic55
+namespace ECMABasic55;
+
+public class RuntimeConfiguration
 {
-	public class RuntimeConfiguration
-	{
-		private const string DEFAULT_PREAMBLE = @"ECMA-55 MINIMAL BASIC RUNTIME ENVIRONMENT
+	private const string DEFAULT_PREAMBLE = @"ECMA-55 MINIMAL BASIC RUNTIME ENVIRONMENT
 USAGE: ECMABASIC55 {OPTIONAL FILE PATH}";
-		private RuntimeConfiguration()
-		{
-			var config = new ConfigurationBuilder()
-				.AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
-				.Build();
+	private RuntimeConfiguration()
+	{
+		var config = new ConfigurationBuilder()
+			.AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
+			.Build();
 
-			Preamble = GetValueOrDefault(config, "preamble", DEFAULT_PREAMBLE);
+		Preamble = GetValueOrDefault(config, "preamble", DEFAULT_PREAMBLE);
+	}
+
+	public static RuntimeConfiguration Instance { get; } = new RuntimeConfiguration();
+
+	public string Preamble { get; }
+
+	private T GetValueOrDefault<T>(IConfiguration config, string key, T defaultValue)
+	{
+		var section = config.GetSection(key);
+		var value = section.Value;
+		if (value == null)
+		{
+			return defaultValue;
 		}
-
-		public static RuntimeConfiguration Instance { get; } = new RuntimeConfiguration();
-
-		public string Preamble { get; }
-
-		private T GetValueOrDefault<T>(IConfiguration config, string key, T defaultValue)
+		else
 		{
-			var section = config.GetSection(key);
-			var value = section.Value;
-			if (value == null)
-			{
-				return defaultValue;
-			}
-			else
-			{
-				return (T)Convert.ChangeType(value, typeof(T));
-			}
+			return (T)Convert.ChangeType(value, typeof(T));
 		}
 	}
 }

--- a/src/ECMABasic55/RuntimeInterpreter.cs
+++ b/src/ECMABasic55/RuntimeInterpreter.cs
@@ -6,74 +6,73 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace ECMABasic55
+namespace ECMABasic55;
+
+/// <summary>
+/// The core interpreter with immediate-mode statements tacked on.
+/// </summary>
+public class RuntimeInterpreter : Interpreter
 {
-	/// <summary>
-	/// The core interpreter with immediate-mode statements tacked on.
-	/// </summary>
-	public class RuntimeInterpreter : Interpreter
+	private readonly List<StatementParser> _immediateStatements;
+
+	public RuntimeInterpreter(IBasicConfiguration config = null)
+		: base(config)
 	{
-		private readonly List<StatementParser> _immediateStatements;
-
-		public RuntimeInterpreter(IBasicConfiguration config = null)
-			: base(config)
+		_immediateStatements = new List<StatementParser>()
 		{
-			_immediateStatements = new List<StatementParser>()
-			{
-				new RunStatementParser(),
-				new NewStatementParser(),
-				new ContinueStatementParser(),
-				new LoadStatementParser(),
-				new ListStatementParser(),
-				new SaveStatementParser(),
-			};
-		}
+			new RunStatementParser(),
+			new NewStatementParser(),
+			new ContinueStatementParser(),
+			new LoadStatementParser(),
+			new ListStatementParser(),
+			new SaveStatementParser(),
+		};
+	}
 
-		public IStatement ProcessImmediate(IEnvironment env, string text)
+	public IStatement ProcessImmediate(IEnvironment env, string text)
+	{
+		try
 		{
-			try
-			{
-				_reader = ComplexTokenReader.FromText(text);
+			_reader = ComplexTokenReader.FromText(text);
 
-				if (ProcessBlock(env, null))
+			if (ProcessBlock(env, null))
+			{
+				return null;
+			}
+			else
+			{
+				ProcessSpace(false);
+				var statement = ProcessStatement(null, false);
+				if (statement == null)
 				{
-					return null;
+					statement = ProcessImmediateStatement();
 				}
-				else
-				{
-					ProcessSpace(false);
-					var statement = ProcessStatement(null, false);
-					if (statement == null)
-					{
-						statement = ProcessImmediateStatement();
-					}
 
-					ProcessSpace(false);
-					ProcessEndOfLine();
-					return statement;
-				}
-			}
-			catch (SyntaxException)
-			{
-				throw;
-			}
-			catch (Exception)
-			{
-				throw ExceptionFactory.Syntax();
+				ProcessSpace(false);
+				ProcessEndOfLine();
+				return statement;
 			}
 		}
-
-		private IStatement ProcessImmediateStatement()
+		catch (SyntaxException)
 		{
-			foreach (var parser in _immediateStatements)
-			{
-				var stmt = parser.Parse(_reader);
-				if (stmt != null)
-				{
-					return stmt;
-				}
-			}
-			return null;
+			throw;
 		}
+		catch (Exception)
+		{
+			throw ExceptionFactory.Syntax();
+		}
+	}
+
+	private IStatement ProcessImmediateStatement()
+	{
+		foreach (var parser in _immediateStatements)
+		{
+			var stmt = parser.Parse(_reader);
+			if (stmt != null)
+			{
+				return stmt;
+			}
+		}
+		return null;
 	}
 }

--- a/src/ECMABasic55/Statements/ContinueStatement.cs
+++ b/src/ECMABasic55/Statements/ContinueStatement.cs
@@ -2,32 +2,31 @@
 using ECMABasic.Core.Exceptions;
 using ECMABasic.Core.Statements;
 
-namespace ECMABasic55.Statements
+namespace ECMABasic55.Statements;
+
+/// <summary>
+/// Continue after a program has been stopped.
+/// </summary>
+public class ContinueStatement : IStatement
 {
-	/// <summary>
-	/// Continue after a program has been stopped.
-	/// </summary>
-	public class ContinueStatement : IStatement
+	// TODO: ?CN ERROR if there if the program wasn't STOPped.
+
+	public void Execute(IEnvironment env, bool isImmediate)
 	{
-		// TODO: ?CN ERROR if there if the program wasn't STOPped.
-
-		public void Execute(IEnvironment env, bool isImmediate)
+		if (!isImmediate)
 		{
-			if (!isImmediate)
-			{
-				throw ExceptionFactory.NotAllowedInProgram(env.CurrentLineNumber);
-			}
-
-			if (env.Program[env.CurrentLineNumber].Statement is StopStatement)
-			{
-				env.Program.MoveToNextLine(env);
-			}
-			env.Program.Execute(env);
+			throw ExceptionFactory.NotAllowedInProgram(env.CurrentLineNumber);
 		}
 
-		public string ToListing()
+		if (env.Program[env.CurrentLineNumber].Statement is StopStatement)
 		{
-			return "CONT";
+			env.Program.MoveToNextLine(env);
 		}
+		env.Program.Execute(env);
+	}
+
+	public string ToListing()
+	{
+		return "CONT";
 	}
 }

--- a/src/ECMABasic55/Statements/ListStatement.cs
+++ b/src/ECMABasic55/Statements/ListStatement.cs
@@ -5,83 +5,82 @@ using System;
 using System.Linq;
 using System.Text;
 
-namespace ECMABasic55.Statements
+namespace ECMABasic55.Statements;
+
+public class ListStatement : IStatement
 {
-	public class ListStatement : IStatement
+	private readonly IBasicConfiguration _config;
+
+	public ListStatement(IExpression from, IExpression to, IBasicConfiguration config = null)
 	{
-		private readonly IBasicConfiguration _config;
+		_config = config ?? MinimalBasicConfiguration.Instance;
+		From = from;
+		To = to;
+	}
 
-		public ListStatement(IExpression from, IExpression to, IBasicConfiguration config = null)
+	public IExpression From { get; }
+	public IExpression To { get; }
+
+	public void Execute(IEnvironment env, bool isImmediate)
+	{
+		if (!isImmediate)
 		{
-			_config = config ?? MinimalBasicConfiguration.Instance;
-			From = from;
-			To = to;
+			throw ExceptionFactory.NotAllowedInProgram(env.CurrentLineNumber);
 		}
 
-		public IExpression From { get; }
-		public IExpression To { get; }
-
-		public void Execute(IEnvironment env, bool isImmediate)
+		if (env.Program.Length == 0)
 		{
-			if (!isImmediate)
-			{
-				throw ExceptionFactory.NotAllowedInProgram(env.CurrentLineNumber);
-			}
-
-			if (env.Program.Length == 0)
-			{
-				return;
-			}
-
-			var fromLineNumber = (int)((From == null) ? env.Program.First().LineNumber : Convert.ToInt32(From.Evaluate(env)));
-			if (fromLineNumber < 0)
-			{
-				throw ExceptionFactory.LineNumberOutOfRange(fromLineNumber, env.CurrentLineNumber);
-			}
-
-			if ((From != null) && (To == null))
-			{
-				env.ValidateLineNumber(fromLineNumber, true);
-				env.Print(env.Program[fromLineNumber].ToListing());
-				return;
-			}
-
-			var toLineNumber = (To == null) ? env.Program.Last().LineNumber : Convert.ToInt32(To.Evaluate(env));
-			if ((toLineNumber < fromLineNumber) || (toLineNumber > _config.MaxLineNumber))
-			{
-				throw ExceptionFactory.LineNumberOutOfRange(fromLineNumber, env.CurrentLineNumber);
-			}
-
-			foreach (var line in env.Program)
-			{
-				if (line.LineNumber < fromLineNumber)
-				{
-					continue;
-				}
-				else if (line.LineNumber > toLineNumber)
-				{
-					break;
-				}
-				else
-				{
-					env.Print(line.ToListing());
-				}
-			}
+			return;
 		}
 
-		public string ToListing()
+		var fromLineNumber = (int)((From == null) ? env.Program.First().LineNumber : Convert.ToInt32(From.Evaluate(env)));
+		if (fromLineNumber < 0)
 		{
-			var sb = new StringBuilder();
-			sb.Append("LIST");
-			if (From != null)
-			{
-				sb.AppendFormat(" {0}", From.ToListing());
-			}
-			if (To != null)
-			{
-				sb.AppendFormat("-{0}", To.ToListing());
-			}
-			return sb.ToString();
+			throw ExceptionFactory.LineNumberOutOfRange(fromLineNumber, env.CurrentLineNumber);
 		}
+
+		if ((From != null) && (To == null))
+		{
+			env.ValidateLineNumber(fromLineNumber, true);
+			env.Print(env.Program[fromLineNumber].ToListing());
+			return;
+		}
+
+		var toLineNumber = (To == null) ? env.Program.Last().LineNumber : Convert.ToInt32(To.Evaluate(env));
+		if ((toLineNumber < fromLineNumber) || (toLineNumber > _config.MaxLineNumber))
+		{
+			throw ExceptionFactory.LineNumberOutOfRange(fromLineNumber, env.CurrentLineNumber);
+		}
+
+		foreach (var line in env.Program)
+		{
+			if (line.LineNumber < fromLineNumber)
+			{
+				continue;
+			}
+			else if (line.LineNumber > toLineNumber)
+			{
+				break;
+			}
+			else
+			{
+				env.Print(line.ToListing());
+			}
+		}
+	}
+
+	public string ToListing()
+	{
+		var sb = new StringBuilder();
+		sb.Append("LIST");
+		if (From != null)
+		{
+			sb.AppendFormat(" {0}", From.ToListing());
+		}
+		if (To != null)
+		{
+			sb.AppendFormat("-{0}", To.ToListing());
+		}
+		return sb.ToString();
 	}
 }

--- a/src/ECMABasic55/Statements/LoadStatement.cs
+++ b/src/ECMABasic55/Statements/LoadStatement.cs
@@ -3,37 +3,36 @@ using ECMABasic.Core.Exceptions;
 using System;
 using System.IO;
 
-namespace ECMABasic55.Statements
+namespace ECMABasic55.Statements;
+
+public class LoadStatement : IStatement
 {
-	public class LoadStatement : IStatement
+	public LoadStatement(IExpression path)
 	{
-		public LoadStatement(IExpression path)
+		Path = path;
+	}
+
+	public IExpression Path { get; }
+
+	public void Execute(IEnvironment env, bool isImmediate)
+	{
+		if (!isImmediate)
 		{
-			Path = path;
+			throw ExceptionFactory.NotAllowedInProgram(env.CurrentLineNumber);
 		}
 
-		public IExpression Path { get; }
-
-		public void Execute(IEnvironment env, bool isImmediate)
+		var path = Convert.ToString(Path.Evaluate(env));
+		if (!File.Exists(path))
 		{
-			if (!isImmediate)
-			{
-				throw ExceptionFactory.NotAllowedInProgram(env.CurrentLineNumber);
-			}
-
-			var path = Convert.ToString(Path.Evaluate(env));
-			if (!File.Exists(path))
-			{
-				env.ReportError("% FILE NOT FOUND");
-				return;
-			}
-
-			env.LoadFile(path);
+			env.ReportError("% FILE NOT FOUND");
+			return;
 		}
 
-		public string ToListing()
-		{
-			return string.Concat("LOAD ", Path.ToListing());
-		}
+		env.LoadFile(path);
+	}
+
+	public string ToListing()
+	{
+		return string.Concat("LOAD ", Path.ToListing());
 	}
 }

--- a/src/ECMABasic55/Statements/NewStatement.cs
+++ b/src/ECMABasic55/Statements/NewStatement.cs
@@ -1,23 +1,22 @@
 ﻿using ECMABasic.Core;
 using ECMABasic.Core.Exceptions;
 
-namespace ECMABasic55.Statements
+namespace ECMABasic55.Statements;
+
+public class NewStatement : IStatement
 {
-	public class NewStatement : IStatement
+	public void Execute(IEnvironment env, bool isImmediate)
 	{
-		public void Execute(IEnvironment env, bool isImmediate)
+		if (!isImmediate)
 		{
-			if (!isImmediate)
-			{
-				throw ExceptionFactory.NotAllowedInProgram(env.CurrentLineNumber);
-			}
-
-			env.Clear();
+			throw ExceptionFactory.NotAllowedInProgram(env.CurrentLineNumber);
 		}
 
-		public string ToListing()
-		{
-			return "NEW";
-		}
+		env.Clear();
+	}
+
+	public string ToListing()
+	{
+		return "NEW";
 	}
 }

--- a/src/ECMABasic55/Statements/RunStatement.cs
+++ b/src/ECMABasic55/Statements/RunStatement.cs
@@ -3,56 +3,55 @@ using ECMABasic.Core.Exceptions;
 using System;
 using System.Linq;
 
-namespace ECMABasic55.Statements
+namespace ECMABasic55.Statements;
+
+/// <summary>
+/// Run the current program, optionally specifying a line number to start at.
+/// </summary>
+public class RunStatement : IStatement
 {
-	/// <summary>
-	/// Run the current program, optionally specifying a line number to start at.
-	/// </summary>
-	public class RunStatement : IStatement
+	public RunStatement(IExpression lineNumber)
 	{
-		public RunStatement(IExpression lineNumber)
+		LineNumber = lineNumber;
+	}
+
+	public IExpression LineNumber { get; }
+
+	public void Execute(IEnvironment env, bool isImmediate)
+	{
+		if (!isImmediate)
 		{
-			LineNumber = lineNumber;
+			throw ExceptionFactory.NotAllowedInProgram(env.CurrentLineNumber);
 		}
 
-		public IExpression LineNumber { get; }
-
-		public void Execute(IEnvironment env, bool isImmediate)
+		if (LineNumber != null)
 		{
-			if (!isImmediate)
+			var lineNumber = Convert.ToInt32(LineNumber.Evaluate(env));
+			if (!env.Program.Any(x => x.LineNumber == lineNumber))
 			{
-				throw ExceptionFactory.NotAllowedInProgram(env.CurrentLineNumber);
+				throw ExceptionFactory.UndefinedLineNumber(lineNumber, env.CurrentLineNumber);
 			}
-
-			if (LineNumber != null)
-			{
-				var lineNumber = Convert.ToInt32(LineNumber.Evaluate(env));
-				if (!env.Program.Any(x => x.LineNumber == lineNumber))
-				{
-					throw ExceptionFactory.UndefinedLineNumber(lineNumber, env.CurrentLineNumber);
-				}
-				env.CurrentLineNumber = lineNumber;
-			}
-			else
-			{
-				if (env.Program.Length > 0)
-				{
-					env.CurrentLineNumber = env.Program.OrderBy(x => x.LineNumber).First().LineNumber;
-				}
-			}
-			env.Program.Execute(env);
+			env.CurrentLineNumber = lineNumber;
 		}
-
-		public string ToListing()
+		else
 		{
-			if (LineNumber != null)
+			if (env.Program.Length > 0)
 			{
-				return string.Concat("RUN ", LineNumber.ToListing());
+				env.CurrentLineNumber = env.Program.OrderBy(x => x.LineNumber).First().LineNumber;
 			}
-			else
-			{
-				return "RUN";
-			}
+		}
+		env.Program.Execute(env);
+	}
+
+	public string ToListing()
+	{
+		if (LineNumber != null)
+		{
+			return string.Concat("RUN ", LineNumber.ToListing());
+		}
+		else
+		{
+			return "RUN";
 		}
 	}
 }

--- a/src/ECMABasic55/Statements/SaveStatement.cs
+++ b/src/ECMABasic55/Statements/SaveStatement.cs
@@ -3,33 +3,32 @@ using ECMABasic.Core.Exceptions;
 using System;
 using System.IO;
 
-namespace ECMABasic55.Statements
+namespace ECMABasic55.Statements;
+
+public class SaveStatement : IStatement
 {
-	public class SaveStatement : IStatement
+	public SaveStatement(IExpression path)
 	{
-		public SaveStatement(IExpression path)
+		Path = path;
+	}
+
+	public IExpression Path { get; }
+
+	public void Execute(IEnvironment env, bool isImmediate)
+	{
+		if (!isImmediate)
 		{
-			Path = path;
+			throw ExceptionFactory.NotAllowedInProgram(env.CurrentLineNumber);
 		}
 
-		public IExpression Path { get; }
+		var path = Convert.ToString(Path.Evaluate(env));
 
-		public void Execute(IEnvironment env, bool isImmediate)
-		{
-			if (!isImmediate)
-			{
-				throw ExceptionFactory.NotAllowedInProgram(env.CurrentLineNumber);
-			}
+		var contents = env.Program.ToListing();
+		File.WriteAllText(path, contents);
+	}
 
-			var path = Convert.ToString(Path.Evaluate(env));
-
-			var contents = env.Program.ToListing();
-			File.WriteAllText(path, contents);
-		}
-
-		public string ToListing()
-		{
-			return string.Concat("SAVE ", Path.ToListing());
-		}
+	public string ToListing()
+	{
+		return string.Concat("SAVE ", Path.ToListing());
 	}
 }

--- a/src/ECMABasic55/Statements/SleepStatement.cs
+++ b/src/ECMABasic55/Statements/SleepStatement.cs
@@ -2,25 +2,24 @@
 using System;
 using System.Threading;
 
-namespace ECMABasic55.Statements
+namespace ECMABasic55.Statements;
+
+public class SleepStatement : IStatement
 {
-	public class SleepStatement : IStatement
+	public SleepStatement(IExpression milliseconds)
 	{
-		public SleepStatement(IExpression milliseconds)
-		{
-			Milliseconds = milliseconds;
-		}
+		Milliseconds = milliseconds;
+	}
 
-		public IExpression Milliseconds { get; }
+	public IExpression Milliseconds { get; }
 
-		public void Execute(IEnvironment env, bool isImmediate)
-		{
-			Thread.Sleep(Convert.ToInt32(Milliseconds.Evaluate(env)));
-		}
+	public void Execute(IEnvironment env, bool isImmediate)
+	{
+		Thread.Sleep(Convert.ToInt32(Milliseconds.Evaluate(env)));
+	}
 
-		public string ToListing()
-		{
-			return string.Concat("SLEEP ", Milliseconds.ToListing());
-		}
+	public string ToListing()
+	{
+		return string.Concat("SLEEP ", Milliseconds.ToListing());
 	}
 }


### PR DESCRIPTION
## Summary
Converts all 124 C# files from block-scoped to file-scoped namespace syntax.

## Changes
- **ECMABasic.Core**: 95 files converted
- **ECMABasic55**: 18 files converted  
- **ECMABasic.Test**: 11 files converted

## Pattern Applied
```csharp
// Before
namespace ECMABasic.Core
{
    public class SomeClass { }
}

// After
namespace ECMABasic.Core;

public class SomeClass { }
```

## Benefits
- Reduces indentation by one level
- Modernizes to C# 10 syntax
- Net reduction of 114 lines

## Impact
- **Errors eliminated**: 186 IDE0161 errors
- **Code changes**: Pure syntax modernization, no functional changes
- **Build status**: All IDE style errors resolved ✅

## Note
Build shows 67 CS8xxx nullable errors in ECMABasic55 project - these are pre-existing nullable issues separate from this style modernization. Will be addressed in a follow-up issue.

Closes #11

🤖 Generated with [Claude Code](https://claude.ai/claude-code)